### PR TITLE
use non-static and uniq string for overlay object

### DIFF
--- a/jsk_rviz_plugins/src/overlay_text_display.cpp
+++ b/jsk_rviz_plugins/src/overlay_text_display.cpp
@@ -151,7 +151,7 @@ namespace jsk_rviz_plugin
     ss << "OverlayTextDisplayObject" << count++;
     //MFDClass::onInitialize();
     Ogre::OverlayManager* mOverlayMgr = Ogre::OverlayManager::getSingletonPtr();
-    overlay_ = mOverlayMgr->create("foo");
+    overlay_ = mOverlayMgr->create(ss.str());
     
     //panel_ = static_cast<Ogre::OverlayContainer*> (
     panel_ = static_cast<Ogre::PanelOverlayElement*> (


### PR DESCRIPTION
use non-static and uniq string for overlay object
