### PR TITLE
Fix painter not active problem

### DIFF
--- a/jsk_rviz_plugins/src/pie_chart_display.cpp
+++ b/jsk_rviz_plugins/src/pie_chart_display.cpp
@@ -395,9 +395,7 @@ namespace jsk_rviz_plugin
   {
     boost::mutex::scoped_lock lock(mutex_);
     text_size_ = text_size_property_->getInt();
-    // estimate caption_offset_
-    QPainter painter;
-    QFont font = painter.font();
+    QFont font;
     font.setPointSize(text_size_);
     caption_offset_ = QFontMetrics(font).height();
     


### PR DESCRIPTION
does not create QPainter w/o argument in order to supress the warning mesage of 
"painter not activated"
