### PR TITLE
[jsk_rviz_plugins] fix coloring after disable overlays

### DIFF
--- a/jsk_rviz_plugins/src/pie_chart_display.cpp
+++ b/jsk_rviz_plugins/src/pie_chart_display.cpp
@@ -176,7 +176,9 @@ namespace jsk_rviz_plugin
     
     if (texture_.isNull() ||
         ((width != texture_->getWidth()) || (height != texture_->getHeight() - caption_offset_))) {
+      bool firsttime = true;
       if (!texture_.isNull()) {
+        firsttime = false;
         // remove the texture first if previous texture exists
         Ogre::TextureManager::getSingleton().remove(texture_name_);
       }
@@ -189,8 +191,10 @@ namespace jsk_rviz_plugin
         Ogre::PF_A8R8G8B8,   // pixel format chosen to match a format Qt can use
         Ogre::TU_DEFAULT     // usage
         );
-      panel_material_->getTechnique(0)->getPass(0)->createTextureUnitState(texture_name_);
-      panel_material_->getTechnique(0)->getPass(0)->setSceneBlending(Ogre::SBT_TRANSPARENT_ALPHA);
+      if (firsttime) {
+        panel_material_->getTechnique(0)->getPass(0)->createTextureUnitState(texture_name_);
+        panel_material_->getTechnique(0)->getPass(0)->setSceneBlending(Ogre::SBT_TRANSPARENT_ALPHA);
+      }
     }
   }
 

--- a/jsk_rviz_plugins/src/plotter_2d_display.cpp
+++ b/jsk_rviz_plugins/src/plotter_2d_display.cpp
@@ -174,7 +174,9 @@ namespace jsk_rviz_plugin
     if (texture_.isNull() ||
         ((width != texture_->getWidth()) ||
          (height != texture_->getHeight() - caption_offset_))) {
+      bool firsttime = true;
       if (!texture_.isNull()) {
+        firsttime = false;
         // remove the texture first if previous texture exists
         Ogre::TextureManager::getSingleton().remove(texture_name_);
       }
@@ -189,8 +191,10 @@ namespace jsk_rviz_plugin
         Ogre::PF_A8R8G8B8,   // pixel format chosen to match a format Qt can use
         Ogre::TU_DEFAULT     // usage
         );
-      panel_material_->getTechnique(0)->getPass(0)->createTextureUnitState(texture_name_);
-      panel_material_->getTechnique(0)->getPass(0)->setSceneBlending(Ogre::SBT_TRANSPARENT_ALPHA);
+      if (firsttime) {
+        panel_material_->getTechnique(0)->getPass(0)->createTextureUnitState(texture_name_);
+        panel_material_->getTechnique(0)->getPass(0)->setSceneBlending(Ogre::SBT_TRANSPARENT_ALPHA);
+      }
     }
   }
 


### PR DESCRIPTION
alpha blending goes wrong after disable overlays.
fixed by not calling setSceneBlending twice
