### PR TITLE
overlay sample for groovy

### DIFF
--- a/jsk_rviz_plugins/scripts/overlay_sample.py
+++ b/jsk_rviz_plugins/scripts/overlay_sample.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
+try:
+  from jsk_rviz_plugins.msg import *
+except:
+  import roslib;roslib.load_manifest("jsk_rviz_plugins")
+  from jsk_rviz_plugins.msg import *
 
-from jsk_rviz_plugins.msg import *
 from std_msgs.msg import ColorRGBA, Float32
 import rospy
 import math


### PR DESCRIPTION
When the groovy, the overlay_sample.py show the error.

```
Traceback (most recent call last):
  File "/home/***/ros/groovy/jsk-ros-pkg/jsk_visualization/jsk_rviz_plugins/scripts/overlay_sample.py", line 3, in <module>
    from jsk_rviz_plugins.msg import *
ImportError: No module named jsk_rviz_plugins.msg
```
