### PR TITLE
use geometry package to install orocos_kdl

### DIFF
--- a/jsk_interactive_markers/jsk_interactive_marker/catkin.cmake
+++ b/jsk_interactive_markers/jsk_interactive_marker/catkin.cmake
@@ -58,7 +58,7 @@ generate_messages(
 )
 
 catkin_package(
-    DEPENDS orocos_kdl TinyXML
+    DEPENDS TinyXML
     CATKIN_DEPENDS  geometry_msgs jsk_footstep_msgs tf_conversions actionlib
     INCLUDE_DIRS # TODO include
     LIBRARIES # TODO

--- a/jsk_interactive_markers/jsk_interactive_marker/package.xml
+++ b/jsk_interactive_markers/jsk_interactive_marker/package.xml
@@ -22,7 +22,7 @@
   <build_depend>jsk_pcl_ros</build_depend>
   <build_depend>eigen_conversions</build_depend>
   <build_depend>tf_conversions</build_depend>
-  <build_depend>orocos_kdl</build_depend>
+  <build_depend>geometry</build_depend>
   <build_depend>tinyxml</build_depend>
   <build_depend>cmake_modules</build_depend>
   
@@ -38,7 +38,7 @@
   <run_depend>jsk_pcl_ros</run_depend>
   <run_depend>eigen_conversions</run_depend>
   <run_depend>tf_conversions</run_depend>
-  <run_depend>orocos_kdl</run_depend>
+  <run_depend>geometry</run_depend>
 </package>
 
 


### PR DESCRIPTION
use geometry package to install orocos_kdl, since orocos_kdl is not installed via rosdep https://github.com/ros/rosdistro/pull/4336
