### PR TITLE
Fix the size of under line of target visualizer

### DIFF
--- a/jsk_rviz_plugins/src/target_visualizer_display.cpp
+++ b/jsk_rviz_plugins/src/target_visualizer_display.cpp
@@ -246,7 +246,7 @@ namespace jsk_rviz_plugin
                                   radius_ * sin(45.0 / 180.0 * M_PI) + radius_ / 2.0,
                                   0);
       target_text_node_->setPosition(text_position);
-
+      Ogre::Vector3 msg_size = msg_->GetAABB().getSize();
       text_under_line_->clear();
       text_under_line_->setColor(color.r, color.g, color.b, color.a);
       
@@ -257,9 +257,7 @@ namespace jsk_rviz_plugin
                       radius_ * sin(45.0 / 180.0 * M_PI),
                       0);
       Ogre::Vector3 B(text_position + Ogre::Vector3(- radius_ / 4.0, 0, 0));
-      Ogre::Vector3 C(text_position
-                      + Ogre::Vector3(std::max(radius_ / 2.0, minimum_font_size),
-                                      0, 0));
+      Ogre::Vector3 C(text_position + Ogre::Vector3(msg_size[0], 0, 0));
       text_under_line_->addPoint(A);
       text_under_line_->addPoint(B);
       text_under_line_->addPoint(C);
@@ -393,6 +391,7 @@ namespace jsk_rviz_plugin
   {
     boost::mutex::scoped_lock(mutex_);
     target_name_ = target_name_property_->getStdString();
+    require_update_line_ = true;
   }
   
   void TargetVisualizerDisplay::updateRadius()


### PR DESCRIPTION
the Underline under the target caption should be longer than the text.

![screenshot from 2014-07-17 10 44 48](https://cloud.githubusercontent.com/assets/40454/3607920/01fa9ca2-0d54-11e4-86c7-5abd77ee38e5.png)
