### PR TITLE
Initialize the position of the marker to the frame if ~initial_reference_frame is specified

### DIFF
--- a/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/footstep_marker.h
+++ b/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/footstep_marker.h
@@ -109,6 +109,8 @@ protected:
   bool plan_run_;
   bool wait_snapit_server_;
   bool use_initial_footstep_tf_;
+  bool use_initial_reference_;
+  std::string initial_reference_frame_;
   geometry_msgs::Pose lleg_pose_;
   geometry_msgs::Pose rleg_pose_;
   geometry_msgs::Pose lleg_initial_pose_;


### PR DESCRIPTION
initialize the pose of the marker to the `~initial_reference_frame`. If it is not specified, 
no initialization will be conducted.
