### PR TITLE
Set fixed link for urdf visualization marker

### DIFF
--- a/jsk_interactive_markers/jsk_interactive_marker/euslisp/ik-controller.l
+++ b/jsk_interactive_markers/jsk_interactive_marker/euslisp/ik-controller.l
@@ -1586,6 +1586,7 @@
    (defvar *robot-topic-name* (ros::get-param "~robot_topic_name" "robot"))
    (setq *use-ik-server* (ros::get-param "~use_ik_server" t))
    (setq *frame-id* (ros::get-param "~frame_id" "map"))
+   (setq *one-click-grasp* (ros::get-param "~one_click_grasp" nil))
 
    (defvar *rhand-frame* nil)
    (defvar *lhand-frame* nil)
@@ -1763,9 +1764,11 @@
     (format nil "~A/box_movement" *interactive-pc-nodename*)
     jsk_pcl_ros::BoundingBoxMovement #'send self :box-movement-callback)
 
-   (ros::subscribe
-    (format nil "~A/grasp_pose" *interactive-pc-nodename*)
-    geometry_msgs::PoseStamped #'send self :grasp-pose-callback)
+   (if *one-click-grasp*
+       (ros::subscribe
+        (format nil "~A/grasp_pose" *interactive-pc-nodename*)
+        geometry_msgs::PoseStamped #'send self :grasp-pose-callback)
+     )
 
    ;;(switch-end-coords :id 2)
    (setq *real-robot* (copy-object *robot*))

--- a/jsk_interactive_markers/jsk_interactive_marker/launch/interactive_marker_controller_remote.launch
+++ b/jsk_interactive_markers/jsk_interactive_marker/launch/interactive_marker_controller_remote.launch
@@ -58,6 +58,7 @@
       <param name="robot" value="$(arg ROBOT)"/>
       <param name="use_ik_server" value="false"/>
       <param name="frame_id" value="map"/>
+      <param name="one_click_grasp" value="true"/>
     </node>
 
     <!-- eus-ik-server -->

--- a/jsk_interactive_markers/jsk_interactive_marker/launch/pr2_tabletop_teleop.launch
+++ b/jsk_interactive_markers/jsk_interactive_marker/launch/pr2_tabletop_teleop.launch
@@ -66,6 +66,7 @@
     <node pkg="roseus" type="roseus" name="grasp_ik_controller"
           args="$(find jsk_interactive_marker)/euslisp/ik-controller-main.l">
       <remap from="/robot/joint_state_decompressed" to="/joint_states"/>
+      <param name="one_click_grasp" value="true"/>
     </node>
   </group>
 </group>

--- a/jsk_rviz_plugins/src/overlay_menu_display.cpp
+++ b/jsk_rviz_plugins/src/overlay_menu_display.cpp
@@ -171,6 +171,10 @@ namespace jsk_rviz_plugin
         max_width = w;
       }
     }
+    int w = fm.width(msg->title.c_str());
+    if (max_width < w) {
+      max_width = w;
+    }
     return max_width + menu_padding_x * 2;
   }
 


### PR DESCRIPTION
Set fixed link and offset for humanoid.
These are used in order to set foot on ground.
related to #115
![screenshot_from_2014-10-23 10 21 46](https://cloud.githubusercontent.com/assets/4415085/4746970/3d056f56-5a53-11e4-837b-c7c5970a037c.png)
