### PR TITLE
Fix Overlay menu size

### DIFF
--- a/jsk_rviz_plugins/src/overlay_menu_display.cpp
+++ b/jsk_rviz_plugins/src/overlay_menu_display.cpp
@@ -133,6 +133,9 @@ namespace jsk_rviz_plugin
         ROS_DEBUG("need to resize because the length of menu is different");
         return true;
       }
+      else if (current_menu_->title != next_menu_->title) {
+        return true;
+      }
       else {
         // check all the menu is same or not
         for (size_t i = 0; i < current_menu_->menus.size(); i++) {
@@ -172,6 +175,7 @@ namespace jsk_rviz_plugin
       }
     }
     int w = fm.width(msg->title.c_str());
+    
     if (max_width < w) {
       max_width = w;
     }
@@ -198,20 +202,7 @@ namespace jsk_rviz_plugin
       ROS_DEBUG("request is close and state is closed, we ignore it completely");
       return;
     }
-    // if (!overlay_) {
-    //   static int count = 0;
-    //   rviz::UniformStringStream ss;
-    //   ss << "OverlayMenuDisplayObject" << count++;
-    //   overlay_.reset(new OverlayObject(ss.str()));
-    //   overlay_->show();
-    // }
-    
-    // if (isNeedToResize()) {
-    //   overlay_->updateTextureSize(drawAreaWidth(next_menu_), drawAreaHeight(next_menu_));
-    // }
-    // else {
-    //   ROS_DEBUG("no need to update texture size");
-    // }
+
     if (next_menu_->action == jsk_rviz_plugins::OverlayMenu::ACTION_CLOSE) {
       // need to close...
       if (animation_state_ == CLOSED) {
@@ -342,8 +333,10 @@ namespace jsk_rviz_plugin
     overlay_->setDimensions(overlay_->getTextureWidth(), overlay_->getTextureHeight());
     int window_width = context_->getViewManager()->getRenderPanel()->width();
     int window_height = context_->getViewManager()->getRenderPanel()->height();
-    overlay_->setPosition((window_width - overlay_->getTextureWidth()) / 2.0,
-                          (window_height - overlay_->getTextureHeight()) / 2.0);
+    double window_left = (window_width - (int)overlay_->getTextureWidth()) / 2.0;
+    double window_top = (window_height - (int)overlay_->getTextureHeight()) / 2.0;
+    overlay_->setPosition(window_left, window_top);
+                          
     current_menu_ = next_menu_;
   }
   
@@ -399,8 +392,9 @@ namespace jsk_rviz_plugin
     overlay_->setDimensions(overlay_->getTextureWidth(), overlay_->getTextureHeight());
     int window_width = context_->getViewManager()->getRenderPanel()->width();
     int window_height = context_->getViewManager()->getRenderPanel()->height();
-    overlay_->setPosition((window_width - overlay_->getTextureWidth()) / 2.0,
-                          (window_height - overlay_->getTextureHeight()) / 2.0);
+    double window_left = (window_width - (int)overlay_->getTextureWidth()) / 2.0;
+    double window_top = (window_height - (int)overlay_->getTextureHeight()) / 2.0;
+    overlay_->setPosition(window_left, window_top);
   }
   
   void OverlayMenuDisplay::updateTopic()


### PR DESCRIPTION
fix for https://github.com/jsk-ros-pkg/jsk_visualization/issues/190
- change the size of menu according to the change of title
- fix window position if the window is larger than the rviz

![screenshot_from_2014-11-03 13 33 57](https://cloud.githubusercontent.com/assets/40454/4878591/a62516d6-6312-11e4-89d8-90a38c75758f.png)
