### PR TITLE
changed marker_type because BUTTON_CLICK was not driven

### DIFF
--- a/jsk_interactive_markers/jsk_interactive_marker/src/interactive_point_cloud.cpp
+++ b/jsk_interactive_markers/jsk_interactive_marker/src/interactive_point_cloud.cpp
@@ -248,8 +248,8 @@ void InteractivePointCloud::makeMarker(const sensor_msgs::PointCloud2ConstPtr cl
 
       InteractiveMarkerControl control;
       control.always_visible = true;
-      //control.interaction_mode = visualization_msgs::InteractiveMarkerControl::BUTTON;
-      control.interaction_mode = visualization_msgs::InteractiveMarkerControl::MOVE_3D;
+      control.interaction_mode = visualization_msgs::InteractiveMarkerControl::BUTTON;
+      //control.interaction_mode = visualization_msgs::InteractiveMarkerControl::MOVE_3D;
       control.orientation_mode = visualization_msgs::InteractiveMarkerControl::INHERIT;
 
       int_marker.header.stamp = ros::Time::now();


### PR DESCRIPTION
ポイントクラウドでできるマーカーのタイプを、ボタンに変えました。
そうでないと、visualization_msgs::InteractiveMarkerFeedback::BUTTON_CLICKのイベントが発生せず、結果leftClickPointのコールバックがまったくたちあがらないからです。

マーカーを動かしたいときは、６DofControlを使えば動かすことができます。
