### PR TITLE
added codes to pub relative_pose

### DIFF
--- a/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/interactive_point_cloud.h
+++ b/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/interactive_point_cloud.h
@@ -82,7 +82,7 @@ private:
   std::string marker_name_, topic_;
   ros::NodeHandle nh_;
   ros::NodeHandle pnh_;
-  ros::Publisher pub_marker_pose_, pub_click_point_, pub_left_click_, pub_handle_pose_, pub_handle_pose_array_, pub_box_movement_, pub_grasp_pose_;
+  ros::Publisher pub_marker_pose_, pub_click_point_, pub_left_click_, pub_left_click_relative_, pub_handle_pose_, pub_handle_pose_array_, pub_box_movement_, pub_grasp_pose_;
   ros::Subscriber sub_handle_pose_;
   //ros::Subscriber sub_point_cloud_, sub_bounding_box_;
   message_filters::Subscriber<sensor_msgs::PointCloud2> sub_point_cloud_;

--- a/jsk_interactive_markers/jsk_interactive_marker/src/interactive_point_cloud.cpp
+++ b/jsk_interactive_markers/jsk_interactive_marker/src/interactive_point_cloud.cpp
@@ -35,6 +35,7 @@ InteractivePointCloud::InteractivePointCloud(std::string marker_name,
   //publish
   pub_click_point_ = pnh_.advertise<geometry_msgs::PointStamped>("right_click_point", 1);
   pub_left_click_ = pnh_.advertise<geometry_msgs::PointStamped>("left_click_point", 1);
+  pub_left_click_relative_ = pnh_.advertise<geometry_msgs::PointStamped>("left_click_point_relative", 1);
   pub_marker_pose_ = pnh_.advertise<geometry_msgs::PoseStamped>("marker_pose", 1);
   pub_grasp_pose_ = pnh_.advertise<geometry_msgs::PoseStamped>("grasp_pose", 1);
   pub_box_movement_ = pnh_.advertise<jsk_pcl_ros::BoundingBoxMovement>("box_movement", 1);
@@ -146,6 +147,14 @@ void InteractivePointCloud::leftClickPoint( const visualization_msgs::Interactiv
   click_point.header = feedback->header;
   click_point.header.stamp = ros::Time::now();
   pub_left_click_.publish(click_point);
+  tf::Transform transform;
+  tf::poseMsgToTF(feedback->pose, transform);
+  tf::Vector3 vector_absolute(feedback->mouse_point.x, feedback->mouse_point.y, feedback->mouse_point.z); 
+  tf::Vector3 vector_relative=transform.inverse() * vector_absolute;
+  click_point.point.x=vector_relative.getX();
+  click_point.point.y=vector_relative.getY();   
+  click_point.point.z=vector_relative.getZ();
+  pub_left_click_relative_.publish(click_point);
 }
 
 void InteractivePointCloud::hide( const visualization_msgs::InteractiveMarkerFeedbackConstPtr &feedback )


### PR DESCRIPTION
クリックされたポイントクラウドの座標は、マーカー全体が動くとその分だけ動いていましたが、
マーカーが動いても動かない、元のポイントクラウドの原点から相対して見た位置を
返すようプログラムを加えました。

マーカーが動いたときに、クリックされたポイントがマーカーと共に動いていい場合と、
もとの座標系で欲しい場合がありますが、今までどおり動いていい場合は
/interactive_point_cloud/left_click_point
もとのクラウド上の座標を知りたい場合は
/interactive_point_cloud/left_click_point_relative
をサブスクライブしてください。
