### PR TITLE
changed dyn_reconfogure_effect_trigger_to_switch

### DIFF
--- a/jsk_interactive_markers/jsk_interactive_marker/src/transformable_interactive_server.cpp
+++ b/jsk_interactive_markers/jsk_interactive_marker/src/transformable_interactive_server.cpp
@@ -58,7 +58,7 @@ TransformableInteractiveServer::~TransformableInteractiveServer()
 void TransformableInteractiveServer::configCallback(InteractiveSettingConfig &config, uint32_t level)
   {
     boost::mutex::scoped_lock lock(mutex_);
-    display_interactive_manipulator_=config.display_interactive_manipulator;
+    display_interactive_manipulator_ = config.display_interactive_manipulator;
     for (std::map<string, TransformableObject* >::iterator itpairstri = transformable_objects_map_.begin(); itpairstri != transformable_objects_map_.end(); itpairstri++) {
       TransformableObject* tobject = itpairstri->second;
       tobject->setInteractiveMarkerSetting(config);


### PR DESCRIPTION
dynamic_reconfigureで、インタラクティブマーカーのコントローラを
設定する機能があったのですが、それがトリガーになっていて、ボタンを変えた
そのときだけしかモードが変わっていませんでした。
その状態を保持しておいて、スイッチの機能を持つように変更しました。
