### PR TITLE
add_mesh_model_in_transformable_marker

### DIFF
--- a/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/transformable_interactive_server.h
+++ b/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/transformable_interactive_server.h
@@ -51,6 +51,7 @@ namespace jsk_interactive_marker
     void insertNewBox( std::string frame_id, std::string name, std::string description );
     void insertNewCylinder( std::string frame_id, std::string name, std::string description );
     void insertNewTorus( std::string frame_id, std::string name, std::string description );
+    void insertNewMesh( std::string frame_id, std::string name, std::string description , std::string mesh_resource, bool mesh_use_embedded_materials);
 
     void insertNewObject(TransformableObject* tobject, std::string name);
     void eraseObject(std::string name);

--- a/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/transformable_object.h
+++ b/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/transformable_object.h
@@ -97,6 +97,30 @@ namespace jsk_interactive_marker
 
 namespace jsk_interactive_marker
 {
+  class TransformableMesh: public TransformableObject
+  {
+  public:
+    TransformableMesh(std::string frame, std::string name, std::string description, std::string mesh_resource, bool mesh_use_embedded_materials);
+    visualization_msgs::Marker getVisualizationMsgMarker();
+    void setRGBA( float r , float g, float b, float a){mesh_r_=r;mesh_g_=g;mesh_b_=b;mesh_a_=a;};
+    void getRGBA(float &r , float &g, float &b, float &a){r=mesh_r_;g=mesh_g_;b=mesh_b_;a=mesh_a_;};
+    void setXYZ( float x , float y, float z){return;};
+    void getXYZ(float &x, float &y, float&z){return;};
+    bool setX(std_msgs::Float32 x){return true;};
+    bool setY(std_msgs::Float32 y){return true;};
+    bool setZ(std_msgs::Float32 z){return true;};
+    float getInteractiveMarkerScale(){return marker_scale_;};
+    float marker_scale_;
+    std::string mesh_resource_;
+    float mesh_r_;
+    float mesh_g_;
+    float mesh_b_;
+    float mesh_a_;
+  };
+};
+
+namespace jsk_interactive_marker
+{
   class TransformableTorus: public TransformableObject
   {
   public:

--- a/jsk_interactive_markers/jsk_interactive_marker/src/transformable_interactive_server.cpp
+++ b/jsk_interactive_markers/jsk_interactive_marker/src/transformable_interactive_server.cpp
@@ -286,6 +286,7 @@ bool TransformableInteractiveServer::setDimensionsService(jsk_interactive_marker
       tobject->setRZ(req.dimensions.radius, req.dimensions.z);
     } else if (tobject->getType() == jsk_rviz_plugins::TransformableMarkerOperate::TORUS) {
       tobject->setRSR(req.dimensions.radius, req.dimensions.small_radius);
+    } else if (tobject->getType() == jsk_rviz_plugins::TransformableMarkerOperate::MESH_RESOURCE) {
     }
     publishMarkerDimensions();
     updateTransformableObject(tobject);
@@ -310,7 +311,9 @@ bool TransformableInteractiveServer::getDimensionsService(jsk_interactive_marker
       tobject->getRZ(res.dimensions.radius, res.dimensions.z);
     } else if (tobject->getType() == jsk_rviz_plugins::TransformableMarkerOperate::TORUS) {
       tobject->getRSR(res.dimensions.radius, res.dimensions.small_radius);
+    } else if (tobject->getType() == jsk_rviz_plugins::TransformableMarkerOperate::MESH_RESOURCE) {
     }
+
     res.dimensions.type = tobject->getType();
   }
   return true;
@@ -329,6 +332,7 @@ void TransformableInteractiveServer::publishMarkerDimensions()
       tobject->getRZ(marker_dimensions.radius, marker_dimensions.z);
     } else if (tobject->getType() == jsk_rviz_plugins::TransformableMarkerOperate::TORUS) {
       tobject->getRSR(marker_dimensions.radius, marker_dimensions.small_radius);
+    } else if (tobject->getType() == jsk_rviz_plugins::TransformableMarkerOperate::MESH_RESOURCE) {
     }
     marker_dimensions.type = tobject->type_;
     marker_dimensions_pub_.publish(marker_dimensions);
@@ -345,6 +349,8 @@ bool TransformableInteractiveServer::requestMarkerOperateService(jsk_rviz_plugin
       insertNewCylinder(req.operate.frame_id, req.operate.name, req.operate.description);
     } else if (req.operate.type == jsk_rviz_plugins::TransformableMarkerOperate::TORUS) {
       insertNewTorus(req.operate.frame_id, req.operate.name, req.operate.description);
+    } else if (req.operate.type == jsk_rviz_plugins::TransformableMarkerOperate::MESH_RESOURCE) {
+      insertNewMesh(req.operate.frame_id, req.operate.name, req.operate.description, req.operate.mesh_resource, req.operate.mesh_use_embedded_materials);
     }
     return true;
     break;
@@ -383,6 +389,10 @@ bool TransformableInteractiveServer::requestMarkerOperateService(jsk_rviz_plugin
       insertNewTorus(tobject->frame_id_, req.operate.name, req.operate.description);
       new_tobject = transformable_objects_map_[req.operate.name];
       new_tobject->setRSR(r, sr);
+      new_tobject->setPose(tobject->getPose());
+    } else if (tobject->type_ == jsk_rviz_plugins::TransformableMarkerOperate::MESH_RESOURCE) {
+      insertNewMesh(tobject->frame_id_, req.operate.name, req.operate.description, req.operate.mesh_resource, req.operate.mesh_use_embedded_materials);
+      new_tobject = transformable_objects_map_[req.operate.name];
       new_tobject->setPose(tobject->getPose());
     }
     float r, g, b, a;
@@ -473,6 +483,12 @@ void TransformableInteractiveServer::insertNewTorus( std::string frame_id, std::
 {
   TransformableTorus* transformable_torus = new TransformableTorus(0.45, 0.2, torus_udiv_, torus_vdiv_, 0.5, 0.5, 0.5, 1.0, frame_id, name, description);
   insertNewObject(transformable_torus, name);
+}
+
+void TransformableInteractiveServer::insertNewMesh( std::string frame_id, std::string name, std::string description, std::string mesh_resource, bool mesh_use_embedded_materials)
+{
+  TransformableMesh* transformable_mesh = new TransformableMesh(frame_id, name, description, mesh_resource, mesh_use_embedded_materials);
+  insertNewObject(transformable_mesh, name);
 }
 
 void TransformableInteractiveServer::insertNewObject( TransformableObject* tobject , std::string name )

--- a/jsk_interactive_markers/jsk_interactive_marker/src/transformable_object.cpp
+++ b/jsk_interactive_markers/jsk_interactive_marker/src/transformable_object.cpp
@@ -232,6 +232,7 @@ namespace jsk_interactive_marker{
 }
 
 namespace jsk_interactive_marker{
+
   TransformableBox::TransformableBox( float length , float r, float g, float b, float a, std::string frame, std::string name, std::string description){
     box_x_ = box_y_ = box_z_ = length;
 
@@ -270,6 +271,28 @@ namespace jsk_interactive_marker{
     marker_.color.g = box_g_;
     marker_.color.b = box_b_;
     marker_.color.a = box_a_;
+    return marker_;
+  }
+}
+
+namespace jsk_interactive_marker{
+
+  TransformableMesh::TransformableMesh( std::string frame, std::string name, std::string description, std::string mesh_resource, bool mesh_use_embedded_materials){
+    marker_scale_ = 0.5;
+    marker_.type = visualization_msgs::Marker::MESH_RESOURCE;
+    type_ = jsk_rviz_plugins::TransformableMarkerOperate::MESH_RESOURCE;
+    marker_.mesh_resource = mesh_resource;
+    marker_.mesh_use_embedded_materials = mesh_use_embedded_materials;
+    frame_id_ = frame;
+    name_ = name;
+    description_ = description;
+  }
+
+  visualization_msgs::Marker TransformableMesh::getVisualizationMsgMarker(){
+    marker_.color.r = mesh_r_;
+    marker_.color.g = mesh_g_;
+    marker_.color.b = mesh_b_;
+    marker_.color.a = mesh_a_;
     return marker_;
   }
 }

--- a/jsk_rviz_plugins/msg/TransformableMarkerOperate.msg
+++ b/jsk_rviz_plugins/msg/TransformableMarkerOperate.msg
@@ -1,6 +1,7 @@
 uint8 BOX=0
 uint8 CYLINDER=1
 uint8 TORUS=2
+uint8 MESH_RESOURCE=3
 
 uint8 INSERT=0
 uint8 ERASE=1
@@ -13,3 +14,5 @@ int32 action
 string frame_id
 string name
 string description
+string mesh_resource
+bool mesh_use_embedded_materials


### PR DESCRIPTION
![drill](https://cloud.githubusercontent.com/assets/7259700/6410476/fea7ad72-beb2-11e4-89be-a925fa683d09.png)
transformable_markerにmeshを表示する機能を加えました。
msgを変えましたが、 
https://github.com/jsk-ros-pkg/jsk_common/commit/32652fb76e090f8929a5aae8482d86a419554d54
と同じたぐいの変更なので大丈夫です。