### PR TITLE
[jsk_rviz_plugins] Use jsk_pcl_ros/geo_util to reconstruct 3d information in SimpleOccupancyGridArrayDisplay

### DIFF
--- a/jsk_rviz_plugins/src/simple_occupancy_grid_array_display.cpp
+++ b/jsk_rviz_plugins/src/simple_occupancy_grid_array_display.cpp
@@ -32,12 +32,13 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
-
+#define BOOST_PARAMETER_MAX_ARITY 7
 #include "simple_occupancy_grid_array_display.h"
 #include <Eigen/Geometry>
 #include <jsk_pcl_ros/pcl_conversion_util.h>
 #include <jsk_topic_tools/color_utils.h>
 #include "rviz_util.h"
+#include <jsk_pcl_ros/geo_util.h>
 
 namespace jsk_rviz_plugins
 {
@@ -118,12 +119,8 @@ namespace jsk_rviz_plugins
       
       // coefficients
       geometry_msgs::Pose plane_pose;
-      Eigen::Vector3f normal(grid.coefficients[0], grid.coefficients[1], grid.coefficients[2]);
-      double d = grid.coefficients[3];
-      Eigen::Quaternionf rot;
-      rot.setFromTwoVectors(Eigen::Vector3f::UnitZ(), normal);
-      Eigen::Affine3f plane_pose_eigen
-        = Eigen::Affine3f::Identity() * rot * Eigen::Translation3f(0, 0, d);
+      jsk_pcl_ros::Plane::Ptr plane(new jsk_pcl_ros::Plane(grid.coefficients));
+      Eigen::Affine3f plane_pose_eigen = plane->coordinates();
       tf::poseEigenToMsg(plane_pose_eigen, plane_pose);
       if(!context_->getFrameManager()->transform(grid.header, plane_pose,
                                                  position,


### PR DESCRIPTION
need to release new version of jsk_recognition