### PR TITLE
[jsk_interactive_marker] Fix dependency name pr2eus_moveit -> jsk_pr2eus

### DIFF
--- a/jsk_interactive_markers/jsk_interactive_marker/package.xml
+++ b/jsk_interactive_markers/jsk_interactive_marker/package.xml
@@ -35,7 +35,7 @@
   <build_depend>roslib</build_depend>
   <build_depend>message_filters</build_depend>
   <build_depend>jsk_rviz_plugins</build_depend>
-  <build_depend>pr2eus_moveit</build_depend>
+  <build_depend>jsk_pr2eus</build_depend>
   <build_depend>jsk_recognition_msgs</build_depend>
   <build_depend>jsk_topic_tools</build_depend> 
   <run_depend>roseus</run_depend>
@@ -59,7 +59,7 @@
   <run_depend>jsk_rviz_plugins</run_depend>
   <run_depend>jsk_topic_tools</run_depend>
   <run_depend>jsk_recognition_msgs</run_depend>
-  <run_depend>pr2eus_moveit</run_depend>
+  <run_depend>jsk_pr2eus</run_depend>
 </package>
 
 


### PR DESCRIPTION
This change fixes error message below::
```
% rosdep install --from-paths . -r -y
...
jsk_interactive_marker: Cannot locate rosdep definition for [pr2eus_moveit]
...
```