### PR TITLE
[jsk_rviz_plugins][OverlayImage] Automatically setup size with negative value

### DIFF
--- a/jsk_rviz_plugins/src/overlay_image_display.h
+++ b/jsk_rviz_plugins/src/overlay_image_display.h
@@ -74,6 +74,7 @@ namespace jsk_rviz_plugins
     boost::shared_ptr<image_transport::ImageTransport> it_;
     image_transport::Subscriber sub_;
     sensor_msgs::Image::ConstPtr msg_;
+    bool is_msg_available_;
     bool require_update_;
 
     virtual void redraw();


### PR DESCRIPTION
### Advantages

1.  Easily set width or height with correct aspect ratio (also available static width and height setup)
![overlay_image_auto_size_setup](https://cloud.githubusercontent.com/assets/4310419/8872986/e886893e-323c-11e5-821e-d92e19807f77.gif)

2.  Automatically adjust size changing topic image
![overlay_image_auto_size_setup2](https://cloud.githubusercontent.com/assets/4310419/8874465/3cf64270-324c-11e5-993f-51a3341de0ca.gif)

