### PR TITLE
add jsk_recognition_msgs to catkin_package(CATKIN_DEPEND)

### DIFF
--- a/jsk_interactive_markers/jsk_interactive_marker/CMakeLists.txt
+++ b/jsk_interactive_markers/jsk_interactive_marker/CMakeLists.txt
@@ -120,7 +120,7 @@ generate_messages(
 
 catkin_package(
     DEPENDS TinyXML
-    CATKIN_DEPENDS  geometry_msgs jsk_footstep_msgs tf_conversions actionlib jsk_rviz_plugins
+    CATKIN_DEPENDS  geometry_msgs jsk_footstep_msgs tf_conversions actionlib jsk_rviz_plugins jsk_recognition_msgs
     INCLUDE_DIRS include # TODO include
     LIBRARIES jsk_interactive_marker # TODO
 )


### PR DESCRIPTION
I'm not sure but this may fix problem at -> https://github.com/jsk-ros-pkg/jsk-ros-pkg-unreleased/commit/77159929a0c41d3b92ffae098d1c02c3862430ee
```
-- Using CATKIN_TEST_RESULTS_DIR: /home/travis/ros/ws_jsk-ros-pkg-unreleased/build/drc_task_common_deprecated/test_results
-- Looking for include files CMAKE_HAVE_PTHREAD_H
-- Looking for include files CMAKE_HAVE_PTHREAD_H - found
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE 
-- Found gtest sources under '/usr/src/gtest': gtests will be built
-- catkin 0.5.90
-- Using these message generators: gencpp;geneus;genlisp;genpy
CMake Error at /opt/ros/hydro/share/genmsg/cmake/genmsg-extras.cmake:255 (message):
  Messages depends on unknown pkg: jsk_recognition_msgs (Missing
  find_package(jsk_recognition_msgs?))
Call Stack (most recent call first):
  catkin.cmake:11 (generate_messages)
  CMakeLists.txt:2 (include)

```