### PR TITLE
[jsk_rviz_plugins] Disable `show coords` in default in BoundingBoxDisplay

### DIFF
--- a/jsk_rviz_plugins/src/bounding_box_array_display.cpp
+++ b/jsk_rviz_plugins/src/bounding_box_array_display.cpp
@@ -64,7 +64,7 @@ namespace jsk_rviz_plugins
       "line width of the edges",
       this, SLOT(updateLineWidth()));
     show_coords_property_ = new rviz::BoolProperty(
-      "show coords", true,
+      "show coords", false,
       "show coordinate of bounding box",
       this, SLOT(updateShowCoords()));
   }


### PR DESCRIPTION
Modified:
	 jsk_rviz_plugins/src/bounding_box_array_display.cpp