### PR TITLE
[jsk_interactive_marker] Add ~use_2d parameter to remove z-axis translation  and rotation around x-y axis

### DIFF
--- a/jsk_interactive_markers/jsk_interactive_marker/cfg/FootstepMarker.cfg
+++ b/jsk_interactive_markers/jsk_interactive_marker/cfg/FootstepMarker.cfg
@@ -16,5 +16,6 @@ gen = ParameterGenerator ()
 gen.add("use_projection_service", bool_t, 0, "", False)
 gen.add("use_projection_topic", bool_t, 0, "", False)
 gen.add("use_plane_snap", bool_t, 0, "", False)
+gen.add("use_2d", bool_t, 0, "", False)
 
 exit (gen.generate (PACKAGE, "jsk_interactive_marker", "FootstepMarker"))

--- a/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/footstep_marker.h
+++ b/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/footstep_marker.h
@@ -153,6 +153,7 @@ protected:
   bool use_initial_reference_;
   bool always_planning_;
   bool lleg_first_;
+  bool use_2d_;
   std::string initial_reference_frame_;
   geometry_msgs::Pose lleg_pose_;
   geometry_msgs::Pose rleg_pose_;

--- a/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/interactive_marker_helpers.h
+++ b/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/interactive_marker_helpers.h
@@ -50,9 +50,9 @@ visualization_msgs::InteractiveMarker makeEmptyMarker( const char *frame_id = ""
 visualization_msgs::Marker makeBox( float scale );
 
 visualization_msgs::Marker makeSphere( float scale );
-
+void add3Dof2DControl( visualization_msgs::InteractiveMarker &msg, bool fixed = false);
 void add6DofControl( visualization_msgs::InteractiveMarker &msg, bool fixed = false );
- void addVisible6DofControl( visualization_msgs::InteractiveMarker &msg, bool fixed = false, bool visible = true );
+void addVisible6DofControl( visualization_msgs::InteractiveMarker &msg, bool fixed = false, bool visible = true );
 
 
 visualization_msgs::InteractiveMarkerControl& makeBoxControl( visualization_msgs::InteractiveMarker &msg );

--- a/jsk_interactive_markers/jsk_interactive_marker/src/footstep_marker.cpp
+++ b/jsk_interactive_markers/jsk_interactive_marker/src/footstep_marker.cpp
@@ -227,6 +227,7 @@ void FootstepMarker::configCallback(Config& config, uint32_t level)
   use_projection_topic_ = config.use_projection_topic;
   use_projection_service_ = config.use_projection_service;
   use_plane_snap_ = config.use_plane_snap;
+  use_2d_ = config.use_2d;
 }
 
 // a function to read double value from XmlRpcValue.
@@ -781,7 +782,12 @@ void FootstepMarker::initializeInteractiveMarker() {
 
   int_marker.controls.push_back( right_box_control );
   if (show_6dof_control_) {
-    im_helpers::add6DofControl(int_marker, false);
+    if (use_2d_) {
+      im_helpers::add3Dof2DControl(int_marker, false);
+    }
+    else {
+      im_helpers::add6DofControl(int_marker, false);
+    }
   }
   
   server_->insert(int_marker,

--- a/jsk_interactive_markers/jsk_interactive_marker/src/interactive_marker_helpers.cpp
+++ b/jsk_interactive_markers/jsk_interactive_marker/src/interactive_marker_helpers.cpp
@@ -93,7 +93,43 @@ visualization_msgs::Marker makeSphere( float scale )
   return marker;
 }
 
-  void add6DofControl( visualization_msgs::InteractiveMarker &msg, bool fixed)
+void add3Dof2DControl( visualization_msgs::InteractiveMarker &msg, bool fixed)
+{
+  visualization_msgs::InteractiveMarkerControl control;
+
+  if(fixed)
+    control.orientation_mode = visualization_msgs::InteractiveMarkerControl::FIXED;
+
+  control.orientation.w = 1;
+  control.orientation.x = 1;
+  control.orientation.y = 0;
+  control.orientation.z = 0;
+  // control.interaction_mode = visualization_msgs::InteractiveMarkerControl::ROTATE_AXIS;
+  // msg.controls.push_back(control);
+  control.interaction_mode = visualization_msgs::InteractiveMarkerControl::MOVE_AXIS;
+  msg.controls.push_back(control);
+
+  control.orientation.w = 1;
+  control.orientation.x = 0;
+  control.orientation.y = 1;
+  control.orientation.z = 0;
+  control.interaction_mode = visualization_msgs::InteractiveMarkerControl::ROTATE_AXIS;
+  msg.controls.push_back(control);
+  // control.interaction_mode = visualization_msgs::InteractiveMarkerControl::MOVE_AXIS;
+  // msg.controls.push_back(control);
+
+  control.orientation.w = 1;
+  control.orientation.x = 0;
+  control.orientation.y = 0;
+  control.orientation.z = 1;
+  // control.interaction_mode = visualization_msgs::InteractiveMarkerControl::ROTATE_AXIS;
+  // msg.controls.push_back(control);
+  control.interaction_mode = visualization_msgs::InteractiveMarkerControl::MOVE_AXIS;
+  msg.controls.push_back(control);
+
+}
+
+void add6DofControl( visualization_msgs::InteractiveMarker &msg, bool fixed)
 {
   visualization_msgs::InteractiveMarkerControl control;
 


### PR DESCRIPTION


Modified:
  - jsk_interactive_markers/jsk_interactive_marker/cfg/FootstepMarker.cfg
  - jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/footstep_marker.h
  - jsk_interactive_markers/jsk_interactive_marker/src/footstep_marker.cpp