### PR TITLE
bgr to rgb convertion in video capturing

### DIFF
--- a/jsk_rviz_plugins/src/video_capture_display.cpp
+++ b/jsk_rviz_plugins/src/video_capture_display.cpp
@@ -174,6 +174,7 @@ namespace jsk_rviz_plugins
       QImage src = screenshot.toImage().convertToFormat(QImage::Format_RGB888);
       cv::Mat image(src.height(), src.width(), CV_8UC3,
                     (uchar*)src.bits(), src.bytesPerLine());
+      cv::cvtColor(image, image, CV_BGR2RGB); 
       writer_ << image;
       ++frame_counter_;
       if (frame_counter_ % 100 == 0) {


### PR DESCRIPTION
converting generated opencv image from bgr color channel order to rgb channel order for video capturing with right colors.