### PR TITLE
add rviz_DEFAULT_PLUGIN_LIBRARIES

### DIFF
--- a/jsk_rviz_plugins/CMakeLists.txt
+++ b/jsk_rviz_plugins/CMakeLists.txt
@@ -156,7 +156,7 @@ set(SOURCE_FILES
 )
 
 add_library(jsk_rviz_plugins ${SOURCE_FILES} ${UIC_FILES})
-target_link_libraries(jsk_rviz_plugins ${QT_LIBRARIES} ${catkin_LIBRARIES})
+target_link_libraries(jsk_rviz_plugins ${QT_LIBRARIES} ${catkin_LIBRARIES} ${rviz_DEFAULT_PLUGIN_LIBRARIES})
 add_dependencies(jsk_rviz_plugins jsk_hark_msgs_gencpp ${PROJECT_NAME}_gencpp)
 
 set_target_properties(jsk_rviz_plugins


### PR DESCRIPTION
see https://github.com/ros-visualization/rviz/pull/979

our package start failing recently, due to
```
00:56:15 /tmp/binarydeb/ros-indigo-jsk-rviz-plugins-1.0.29/src/quiet_interactive_marker_display.cpp:40: undefined reference to `rviz::InteractiveMarkerDisplay::InteractiveMarkerDisplay()'
00:56:15 CMakeFiles/jsk_rviz_plugins.dir/src/quiet_interactive_marker_display.cpp.o: In function `rviz::InteractiveMarkerDisplay::~InteractiveMarkerDisplay()':
00:56:15 /opt/ros/indigo/include/rviz/default_plugin/interactive_marker_display.h:65: undefined reference to `vtable for rviz::InteractiveMarkerDisplay'
00:56:15 CMakeFiles/jsk_rviz_plugins.dir/src/quiet_interactive_marker_display.cpp.o:(.data.rel.ro._ZTIN16jsk_rviz_plugins29QuietInteractiveMarkerDisplayE[_ZTIN16jsk_rviz_plugins29QuietInteractiveMarkerDisplayE]+0x10): undefined reference to `typeinfo for rviz::InteractiveMarkerDisplay'
00:56:15 CMakeFiles/jsk_rviz_plugins.dir/src/quiet_interactive_marker_display.cpp.o:(.data.rel.ro._ZTVN16jsk_rviz_plugins29QuietInteractiveMarkerDisplayE[_ZTVN16jsk_rviz_plugins29QuietInteractiveMarkerDisplayE]+0x10): undefined reference to `rviz::InteractiveMarkerDisplay::metaObject() const'
00:56:15 CMakeFiles/jsk_rviz_plugins.dir/src/quiet_interactive_marker_display.cpp.o:(.data.rel.ro._ZTVN16jsk_rviz_plugins29QuietInteractiveMarkerDisplayE[_ZTVN16jsk_rviz_plugins29QuietInteractiveMarkerDisplayE]+0x18): undefined reference to `rviz::InteractiveMarkerDisplay::qt_metacast(char const*)'
00:56:15 CMakeFiles/jsk_rviz_plugins.dir/src/quiet_interactive_marker_display.cpp.o:(.data.rel.ro._ZTVN16jsk_rviz_plugins29QuietInteractiveMarkerDisplayE[_ZTVN16jsk_rviz_plugins29QuietInteractiveMarkerDisplayE]+0x20): undefined reference to `rviz::InteractiveMarkerDisplay::qt_metacall(QMetaObject::Call, int, void**)'
00:56:15 CMakeFiles/jsk_rviz_plugins.dir/src/quiet_interactive_marker_display.cpp.o:
```

http://build.ros.org/view/Ibin_uT64/job/Ibin_uT64__jsk_rviz_plugins__ubuntu_trusty_amd64__binary/16/console