### PR TITLE
[jsk_rqt_plugins] Check class type of data instead of subscribed topic type in rqt_histgram_plot to support HistgramWithRangeArray

### DIFF
--- a/jsk_rqt_plugins/src/jsk_rqt_plugins/hist.py
+++ b/jsk_rqt_plugins/src/jsk_rqt_plugins/hist.py
@@ -152,7 +152,7 @@ class HistogramPlotWidget(QWidget):
             return
         axes = self.data_plot._canvas.axes
         axes.cla()
-        if self._rosdata.sub.data_class is HistogramWithRange:
+        if isinstance(data_y[-1], HistogramWithRange):
             xs = [y.count for y in data_y[-1].bins]
             pos = [y.min_value for y in data_y[-1].bins]
             widths = [y.max_value - y.min_value for y in data_y[-1].bins]


### PR DESCRIPTION
When subscribing HistgramWithRangeArray in rqt_histogram_plot like /histgram_array/histograms[0], rqt_histogram_plot cause an error at https://github.com/jsk-ros-pkg/jsk_visualization/blob/master/jsk_rqt_plugins/src/jsk_rqt_plugins/hist.py#L161  because self._rosdata.sub.data_class is HistgramWithRangeArray.
