### PR TITLE
[jsk_rviz_plugins] Convert RGB to BGR precisely in video capturing

### DIFF
--- a/jsk_rviz_plugins/src/video_capture_display.cpp
+++ b/jsk_rviz_plugins/src/video_capture_display.cpp
@@ -171,9 +171,10 @@ namespace jsk_rviz_plugins
       rviz::RenderPanel* panel = context_->getViewManager()->getRenderPanel();
       QPixmap screenshot
         = QPixmap::grabWindow(context_->getViewManager()->getRenderPanel()->winId());
-      QImage src = screenshot.toImage().convertToFormat(QImage::Format_RGB888);
+      QImage src = screenshot.toImage().convertToFormat(QImage::Format_RGB888);  // RGB
       cv::Mat image(src.height(), src.width(), CV_8UC3,
-                    (uchar*)src.bits(), src.bytesPerLine());
+                    (uchar*)src.bits(), src.bytesPerLine());  // RGB
+      cv::cvtColor(image, image, CV_RGB2BGR);  // RGB -> BGR
       writer_ << image;
       ++frame_counter_;
       if (frame_counter_ % 100 == 0) {


### PR DESCRIPTION
## Description

The RGB channel order is wrong in video_capture plugin.

Fix #583

!!!The chair is **RED**!!!
<img src="https://cloud.githubusercontent.com/assets/4310419/15990666/08edafa8-30d5-11e6-953e-b0d7a6eeaf99.jpg" width="300px" />

**Before**
<img src="https://cloud.githubusercontent.com/assets/4310419/15990659/d7e53728-30d4-11e6-8018-8bdab5a2b8d2.png" width="500px" />

**After**
<img src="https://cloud.githubusercontent.com/assets/4310419/15990660/dc17fb96-30d4-11e6-874b-030dcfab7538.png" width="500px" />


