### PR TITLE
[jsk_rviz_plugins] Show valid boxes even if invalid box is included

### DIFF
--- a/jsk_rviz_plugins/src/bounding_box_array_display.h
+++ b/jsk_rviz_plugins/src/bounding_box_array_display.h
@@ -70,8 +70,8 @@ namespace jsk_rviz_plugins
     QColor getColor(size_t index,
                     const jsk_recognition_msgs::BoundingBox& box,
                     double min_value, double max_value);
-    virtual bool isValid(
-      const jsk_recognition_msgs::BoundingBoxArray::ConstPtr& msg);
+    virtual bool isValidBoundingBox(
+      const jsk_recognition_msgs::BoundingBox box_msg);
     virtual void hideCoords();
     virtual void showCoords(
       const jsk_recognition_msgs::BoundingBoxArray::ConstPtr& msg);


### PR DESCRIPTION
Why?
----

Currently, bounding boxes visualization is stopped if invalid box is included.
This PR enables the plugin skip the invalid box with warning message and shows valid ones.


cc @furushchev