### PR TITLE
[jsk_interactive_marker] Mode to display interactive manipultor only when selected

### DIFF
--- a/doc/jsk_interactive_marker/nodes/transformable_server_sample.md
+++ b/doc/jsk_interactive_marker/nodes/transformable_server_sample.md
@@ -25,6 +25,15 @@ child_marker_name: 'hand'"
   If `parent_topic_name==empty`, it uses self server,
   and only 1 hierarchy is supported.
 
+* `~display_interactive_manipulator` (Bool, default: `true`)
+
+  Flat to show the 6dof interactive manipulator for all objects.
+
+* `~display_interactive_manipulator_only_selected` (Bool, default: `false`)
+
+  Flat to show the 6dof interactive manipulator only for the selected object.
+  This flag does nothing if `~display_interactive_manipulator` is `false`.
+
 
 ## Usage
 

--- a/doc/jsk_interactive_marker/nodes/transformable_server_sample.md
+++ b/doc/jsk_interactive_marker/nodes/transformable_server_sample.md
@@ -1,38 +1,48 @@
 # transformable_server_sample
+
 ![](../images/transformable_marker.png)
 
 `transformable` provides interactive marker to control some object models.
 
+
 ## Parameters
 * `~server_name`
-  Name of nteractive server.
+
+  Name of interactive server.
 
 * `~use_parent_and_child` (default: `false`)
-  Use `ParentAndChildInteractiveServer`
 
-** if true, you can use associate markers like this
-```
+  Flag for using `ParentAndChildInteractiveServer`.
+
+  If true, you can use associate markers like below:
+
+```bash
 rosservice call /simple_marker/set_parent_marker "parent_topic_name: ''
 parent_marker_name: 'drill'
 child_marker_name: 'hand'"
 ```
-*** if parent_topic_name==empty, it uses self server.
-*** only 1 hierarchy is supported
+
+  If `parent_topic_name==empty`, it uses self server,
+  and only 1 hierarchy is supported.
+
 
 ## Usage
 
-```
+```bash
 roslaunch jsk_interactive_marker urdf_model_marker.launch
 ```
+
 then, in different terminal
 You can insert box marker by this command
-```
+
+```bash
 rosservice call /simple_marker/request_marker_operate "operate: {type: 0, action: 0, frame_id: '', name: '', description: '', mesh_resource: '',
   mesh_use_embedded_materials: false}"
 ```
 
 You can insert model by this command
-```
+
+```bash
 rosservice call /simple_marker/request_marker_operate "operate: {type: 3, action: 0, frame_id: 'map', name: 'hand', description: '', mesh_resource: 'package://hrpsys_ros_bridge_tutorials/models/HRP3HAND_R_meshes/RARM_LINK6_mesh.dae',
   mesh_use_embedded_materials: true}" 
 ```
@@ -63,6 +73,7 @@ You can get marker info by topics below
  * /tf [tf2_msgs/TFMessage] (with marker name, tf is published)
  * /simple_marker/focus_marker_pose_text [jsk_rviz_plugins/OverlayText]
 
+
 ## Services
 You can control markers through topics below
  * /simple_marker/request_marker_operate -> for inserting marker
@@ -83,6 +94,3 @@ You can get marker info through topics below
  * /simple_marker/get_type
  * /simple_marker/get_pose
  * /simple_marker/get_existence
-
-
-

--- a/jsk_interactive_markers/jsk_interactive_marker/cfg/InteractiveSetting.cfg
+++ b/jsk_interactive_markers/jsk_interactive_marker/cfg/InteractiveSetting.cfg
@@ -14,6 +14,7 @@ orientation_enum = gen.enum([gen.const("INHERIT", int_t, 0, "INHERIT"),
                       "orientation")
 
 gen.add("display_interactive_manipulator",   bool_t,   0, "Display Interactive rotate and translate manipulator",  True)
+gen.add("display_interactive_manipulator_only_selected",   bool_t,   0, "Display interactive rotate and translate manipulator when selected.",  False)
 gen.add("interactive_manipulator_orientation", int_t, 0, "interactive_manipulator_orientation", 0, 0, 2,
         edit_method = orientation_enum)
 exit (gen.generate (PACKAGE, "jsk_interactive_marker", "InteractiveSetting"))

--- a/jsk_interactive_markers/jsk_interactive_marker/doc
+++ b/jsk_interactive_markers/jsk_interactive_marker/doc
@@ -1,0 +1,1 @@
+../../doc/jsk_interactive_marker

--- a/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/transformable_interactive_server.h
+++ b/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/transformable_interactive_server.h
@@ -68,6 +68,7 @@ namespace jsk_interactive_marker
     void focusTextPublish();
     void focusPosePublish();
     void focusObjectMarkerNamePublish();
+    void focusInteractiveManipulatorDisplay();
 
     void updateTransformableObject(TransformableObject* tobject);
 
@@ -145,6 +146,7 @@ namespace jsk_interactive_marker
     int torus_udiv_;
     int torus_vdiv_;
     bool display_interactive_manipulator_;
+    bool display_interactive_manipulator_only_selected_;
     bool strict_tf_;
     int interactive_manipulator_orientation_;
     ros::Timer tf_timer;

--- a/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/transformable_interactive_server.h
+++ b/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/transformable_interactive_server.h
@@ -70,6 +70,9 @@ namespace jsk_interactive_marker
     void focusObjectMarkerNamePublish();
     void focusInteractiveManipulatorDisplay();
 
+    void enableInteractiveManipulatorDisplay(const visualization_msgs::InteractiveMarkerFeedbackConstPtr &feedback,
+                                             const bool enable);
+
     void updateTransformableObject(TransformableObject* tobject);
 
     bool getPoseService(jsk_interactive_marker::GetTransformableMarkerPose::Request &req,jsk_interactive_marker::GetTransformableMarkerPose::Response &res, bool for_interactive_control);

--- a/jsk_interactive_markers/jsk_interactive_marker/src/transformable_interactive_server.cpp
+++ b/jsk_interactive_markers/jsk_interactive_marker/src/transformable_interactive_server.cpp
@@ -61,6 +61,12 @@ TransformableInteractiveServer::TransformableInteractiveServer():n_(new ros::Nod
   std::string default_filename;
   n_->param("yaml_filename", yaml_filename, std::string(""));
   yaml_menu_handler_ptr_ = boost::make_shared <YamlMenuHandler> (n_, yaml_filename);
+  yaml_menu_handler_ptr_->_menu_handler.insert(
+    "enable manipulator",
+    boost::bind(&TransformableInteractiveServer::enableInteractiveManipulatorDisplay, this, _1, /*enable=*/true));
+  yaml_menu_handler_ptr_->_menu_handler.insert(
+    "disable manipulator",
+    boost::bind(&TransformableInteractiveServer::enableInteractiveManipulatorDisplay, this, _1, /*enable=*/false));
 
   bool use_parent_and_child;
   n_->param("use_parent_and_child", use_parent_and_child, false);
@@ -508,6 +514,14 @@ void TransformableInteractiveServer::setControlRelativePose(geometry_msgs::Pose 
   server_->setPose(focus_object_marker_name_, tobject->pose_, header);
   yaml_menu_handler_ptr_->applyMenu(server_, focus_object_marker_name_);
   server_->applyChanges();
+}
+
+void TransformableInteractiveServer::enableInteractiveManipulatorDisplay(
+    const visualization_msgs::InteractiveMarkerFeedbackConstPtr &feedback,
+    const bool enable) {
+  TransformableObject* tobject = transformable_objects_map_[focus_object_marker_name_];
+  tobject->setDisplayInteractiveManipulator(enable);
+  updateTransformableObject(tobject);
 }
 
 void TransformableInteractiveServer::focusInteractiveManipulatorDisplay() {

--- a/jsk_interactive_markers/jsk_interactive_marker/src/transformable_interactive_server.cpp
+++ b/jsk_interactive_markers/jsk_interactive_marker/src/transformable_interactive_server.cpp
@@ -4,7 +4,6 @@
 using namespace jsk_interactive_marker;
 
 TransformableInteractiveServer::TransformableInteractiveServer():n_(new ros::NodeHandle("~")){
-  n_->param("display_interactive_manipulator", display_interactive_manipulator_, true);
   n_->param("interactive_manipulator_orientation", interactive_manipulator_orientation_ , 0);
   n_->param("torus_udiv", torus_udiv_, 20);
   n_->param("torus_vdiv", torus_vdiv_, 20);
@@ -89,6 +88,7 @@ void TransformableInteractiveServer::configCallback(InteractiveSettingConfig &co
   {
     boost::mutex::scoped_lock lock(mutex_);
     display_interactive_manipulator_ = config.display_interactive_manipulator;
+    display_interactive_manipulator_only_selected_ = config.display_interactive_manipulator_only_selected;
     interactive_manipulator_orientation_ = config.interactive_manipulator_orientation;
     for (std::map<string, TransformableObject* >::iterator itpairstri = transformable_objects_map_.begin(); itpairstri != transformable_objects_map_.end(); itpairstri++) {
       TransformableObject* tobject = itpairstri->second;
@@ -109,6 +109,7 @@ void TransformableInteractiveServer::processFeedback(
       focusTextPublish();
       focusPosePublish();
       focusObjectMarkerNamePublish();
+      focusInteractiveManipulatorDisplay();
       break;
 
     case visualization_msgs::InteractiveMarkerFeedback::POSE_UPDATE:
@@ -509,6 +510,23 @@ void TransformableInteractiveServer::setControlRelativePose(geometry_msgs::Pose 
   server_->applyChanges();
 }
 
+void TransformableInteractiveServer::focusInteractiveManipulatorDisplay() {
+  if (display_interactive_manipulator_ && display_interactive_manipulator_only_selected_) {
+    for (std::map<string, TransformableObject* >::iterator it = transformable_objects_map_.begin();
+         it != transformable_objects_map_.end(); it++) {
+      std::string object_name = it->first;
+      TransformableObject* tobject = it->second;
+      // display interactive manipulator only for the focused object
+      if (object_name == focus_object_marker_name_) {
+        tobject->setDisplayInteractiveManipulator(true);
+      } else {
+        tobject->setDisplayInteractiveManipulator(false);
+      }
+      updateTransformableObject(tobject);
+    }
+  }
+}
+
 void TransformableInteractiveServer::focusTextPublish(){
   jsk_rviz_plugins::OverlayText focus_text;
   focus_text.text = focus_object_marker_name_;
@@ -606,7 +624,11 @@ void TransformableInteractiveServer::insertNewObject( TransformableObject* tobje
 void TransformableInteractiveServer::SetInitialInteractiveMarkerConfig( TransformableObject* tobject )
 {
   InteractiveSettingConfig config;
-  config.display_interactive_manipulator = display_interactive_manipulator_;
+  if (display_interactive_manipulator_ && !display_interactive_manipulator_only_selected_) {
+    config.display_interactive_manipulator = true;
+  } else {
+    config.display_interactive_manipulator = false;
+  }
   config.interactive_manipulator_orientation = interactive_manipulator_orientation_;
   tobject->setInteractiveMarkerSetting(config);
 }

--- a/jsk_interactive_markers/jsk_interactive_marker/src/transformable_interactive_server.cpp
+++ b/jsk_interactive_markers/jsk_interactive_marker/src/transformable_interactive_server.cpp
@@ -58,7 +58,6 @@ TransformableInteractiveServer::TransformableInteractiveServer():n_(new ros::Nod
 
   // initialize yaml-menu-handler
   std::string yaml_filename;
-  std::string default_filename;
   n_->param("yaml_filename", yaml_filename, std::string(""));
   yaml_menu_handler_ptr_ = boost::make_shared <YamlMenuHandler> (n_, yaml_filename);
   yaml_menu_handler_ptr_->_menu_handler.insert(


### PR DESCRIPTION
## Problems

There are too many manipulators with many objects on rviz.

<img src="https://cloud.githubusercontent.com/assets/4310419/17563445/64b0959e-5f6a-11e6-8a83-985400905b27.png" width="49%" /><img src="https://cloud.githubusercontent.com/assets/4310419/17563449/67927d40-5f6a-11e6-9f45-3ed182639cdd.png" width="49%" />


## Solutions

1. Show interactive manipulator only when the object is selected.
2. Add menu to enable/disable the manipulator.

## Demo Movie

https://drive.google.com/open?id=0B9P1L--7Wd2vQmpoTDcyZHRtNFU


Labels: feature, pkg/jsk_interactive_marker, documentation