### PR TITLE
handleDisplayClick was not going past first group

### DIFF
--- a/jsk_rviz_plugins/src/overlay_picker_tool.cpp
+++ b/jsk_rviz_plugins/src/overlay_picker_tool.cpp
@@ -116,6 +116,7 @@ namespace jsk_rviz_plugins
         return false;
       }
     }
+    return false;
   }
 
   void OverlayPickerTool::onClicked(rviz::ViewportMouseEvent& event)


### PR DESCRIPTION
as after processing a group with no overlay item, it was still returning true by default. It needed to return false to continue the seach