### PR TITLE
[jsk_rviz_plugins] Show available fonts using enum property in OverlayText

### DIFF
--- a/jsk_rviz_plugins/src/overlay_text_display.cpp
+++ b/jsk_rviz_plugins/src/overlay_text_display.cpp
@@ -38,10 +38,12 @@
 #include <rviz/uniform_string_stream.h>
 #include <OGRE/OgreTexture.h>
 #include <OGRE/OgreHardwarePixelBuffer.h>
+#include <QFontDatabase>
 #include <QPainter>
 #include <QStaticText>
 #include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>
+#include <jsk_topic_tools/log_utils.h>
 
 namespace jsk_rviz_plugins
 {
@@ -115,10 +117,16 @@ namespace jsk_rviz_plugins
       this, SLOT(updateBGAlpha()));
     bg_alpha_property_->setMin(0.0);
     bg_alpha_property_->setMax(1.0);
-    font_property_ = new rviz::StringProperty(
+
+    QFontDatabase database;
+    font_families_ = database.families();
+    font_property_ = new rviz::EnumProperty(
       "font", "DejaVu Sans Mono",
       "font", this,
       SLOT(updateFont()));
+    for (size_t i = 0; i < font_families_.size(); i++) {
+      font_property_->addOption(font_families_[i], (int)i);
+    }
   }
   
   OverlayTextDisplay::~OverlayTextDisplay()
@@ -436,7 +444,13 @@ namespace jsk_rviz_plugins
 
   void OverlayTextDisplay::updateFont()
   {
-    font_ = font_property_->getStdString();
+    int font_index = font_property_->getOptionInt();
+    if (font_index < font_families_.size()) {
+      font_ = font_families_[font_index].toStdString();
+    } else {
+      JSK_ROS_FATAL("Unexpected error at selecting font index %d.", font_index);
+      return;
+    }
     if (overtake_color_properties_) {
       require_update_texture_ = true;
     }

--- a/jsk_rviz_plugins/src/overlay_text_display.h
+++ b/jsk_rviz_plugins/src/overlay_text_display.h
@@ -46,6 +46,7 @@
 #include <rviz/properties/bool_property.h>
 #include <rviz/properties/int_property.h>
 #include <rviz/properties/float_property.h>
+#include <rviz/properties/enum_property.h>
 #include <rviz/properties/color_property.h>
 #endif
 
@@ -77,6 +78,7 @@ namespace jsk_rviz_plugins
     int text_size_;
     int line_width_;
     std::string text_;
+    QStringList font_families_;
     std::string font_;
     int left_;
     int top_;
@@ -104,7 +106,7 @@ namespace jsk_rviz_plugins
     rviz::FloatProperty* bg_alpha_property_;
     rviz::ColorProperty* fg_color_property_;
     rviz::FloatProperty* fg_alpha_property_;
-    rviz::StringProperty* font_property_;
+    rviz::EnumProperty* font_property_;
   protected Q_SLOTS:
     void updateTopic();
     void updateOvertakePositionProperties();


### PR DESCRIPTION
For #629 

![screenshot 2016-08-20 15 28 04](https://cloud.githubusercontent.com/assets/4310419/17829469/d7b408a0-66ea-11e6-82b8-cd175074ed79.png)
