### PR TITLE
[jsk_rviz_plugins] Rviz default font is changed from Arial to Liberat…

### DIFF
--- a/jsk_rviz_plugins/src/diagnostics_display.cpp
+++ b/jsk_rviz_plugins/src/diagnostics_display.cpp
@@ -151,7 +151,7 @@ namespace jsk_rviz_plugins
     scene_node_ = scene_manager_->getRootSceneNode()->createChildSceneNode();
     orbit_node_ = scene_node_->createChildSceneNode(); // ??
     line_ = new rviz::BillboardLine(context_->getSceneManager(), scene_node_);
-    msg_ = new rviz::MovableText("not initialized", "Arial", 0.05);
+    msg_ = new rviz::MovableText("not initialized", "Liberation Sans", 0.05);
     msg_->setTextAlignment(rviz::MovableText::H_CENTER,
                            rviz::MovableText::V_ABOVE);
     frame_id_property_->setFrameManager(context_->getFrameManager());

--- a/jsk_rviz_plugins/src/facing_visualizer.cpp
+++ b/jsk_rviz_plugins/src/facing_visualizer.cpp
@@ -295,7 +295,7 @@ namespace jsk_rviz_plugins
       context->getSceneManager(),
       node_);
     target_text_node_ = node_->createChildSceneNode();
-    msg_ = new rviz::MovableText("not initialized", "Arial", 0.05);
+    msg_ = new rviz::MovableText("not initialized", "Liberation Sans", 0.05);
     msg_->setVisible(false);
     msg_->setTextAlignment(rviz::MovableText::H_LEFT,
                            rviz::MovableText::V_ABOVE);

--- a/jsk_rviz_plugins/src/footstep_display.cpp
+++ b/jsk_rviz_plugins/src/footstep_display.cpp
@@ -179,7 +179,7 @@ namespace jsk_rviz_plugins
         // create nodes
         Ogre::SceneNode* node = scene_node_->createChildSceneNode();
         rviz::MovableText* text 
-          = new rviz::MovableText("not initialized", "Arial", 0.05);
+          = new rviz::MovableText("not initialized", "Liberation Sans", 0.05);
         text->setVisible(false);
         text->setTextAlignment(rviz::MovableText::H_CENTER,
                                rviz::MovableText::V_ABOVE);

--- a/jsk_rviz_plugins/src/overlay_diagnostic_display.cpp
+++ b/jsk_rviz_plugins/src/overlay_diagnostic_display.cpp
@@ -380,7 +380,7 @@ namespace jsk_rviz_plugins
   {
     painter.save();
     const double r = size_ / 128.0;
-    QFont font("Arial", font_size * r, font_size * r, QFont::Bold);
+    QFont font("Liberation Sans", font_size * r, font_size * r, QFont::Bold);
     QPen pen;
     QPainterPath path;
     pen.setWidth(1);
@@ -397,7 +397,7 @@ namespace jsk_rviz_plugins
   {
     painter.save();
     const double r = size_ / 128.0;
-    QFont font("Arial", font_size * r, font_size * r, QFont::Bold);
+    QFont font("Liberation Sans", font_size * r, font_size * r, QFont::Bold);
     QPen pen;
     QPainterPath path;
     pen.setWidth(1);
@@ -417,7 +417,7 @@ namespace jsk_rviz_plugins
                                                      const std::string text)
   {
     const double r = size_ / 128.0;
-    QFont font("Arial", font_size * r, font_size * r, false);
+    QFont font("Liberation Sans", font_size * r, font_size * r, false);
     QPen pen;
     QPainterPath path;
     pen.setWidth(1);
@@ -598,7 +598,7 @@ namespace jsk_rviz_plugins
       }
     }
     painter.setPen(QPen(textColor(), 2 * line_width, Qt::SolidLine));
-    painter.setFont(QFont("Arial", 12, QFont::Bold));
+    painter.setFont(QFont("Liberation Sans", 12, QFont::Bold));
     double theta = atan2(S - B, S - A) / M_PI * 180;
     double text_box_height = cos(theta*M_PI/180) * B;
     double text_box_width = (S - A) / cos(theta*M_PI/180) - sin(theta*M_PI/180) * B * 2;

--- a/jsk_rviz_plugins/src/overlay_text_display.cpp
+++ b/jsk_rviz_plugins/src/overlay_text_display.cpp
@@ -229,7 +229,7 @@ namespace jsk_rviz_plugins
       // font
       if (text_size_ != 0) {
         //QFont font = painter.font();
-        QFont font(font_.length() > 0 ? font_.c_str(): "Arial");
+        QFont font(font_.length() > 0 ? font_.c_str(): "Liberation Sans");
         font.setPointSize(text_size_);
         font.setBold(true);
         painter.setFont(font);

--- a/jsk_rviz_plugins/src/pictogram_display.cpp
+++ b/jsk_rviz_plugins/src/pictogram_display.cpp
@@ -313,7 +313,7 @@ namespace jsk_rviz_plugins
                        pictogram_text);
       painter.end();
     }else if( mode_ == jsk_rviz_plugins::Pictogram::STRING_MODE){
-      QFont font("Arial");
+      QFont font("Liberation Sans");
       font.setPointSize(32);
       font.setBold(true);
       painter.setFont(font);


### PR DESCRIPTION
…ionSans (See: https://github.com/ros-visualization/rviz/pull/1141)

@orikuma thanks for contribution, I made PR from your repository, if there is other places we should change, please let me know.

c.f. https://discourse.ros.org/t/notice-removal-of-arial-in-rviz-caused-breaking-changes/2791/1