### PR TITLE
[jsk_rqt_plugins/HistogramPlot] modify to correctly run on kinetic

### DIFF
--- a/jsk_rqt_plugins/sample_scripts/sample_hist_pub.py
+++ b/jsk_rqt_plugins/sample_scripts/sample_hist_pub.py
@@ -7,8 +7,9 @@ import numpy as np
 
 if __name__ == "__main__":
     rospy.init_node("sample_hist_pub")
-    pub = rospy.Publisher("normal_array", Float32MultiArray)
-    pub_range = rospy.Publisher("range_array", HistogramWithRange)
+    pub = rospy.Publisher("normal_array", Float32MultiArray, queue_size=1)
+    pub_range = rospy.Publisher(
+        "range_array", HistogramWithRange, queue_size=1)
     r = rospy.Rate(1)
     while not rospy.is_shutdown():
         data = np.random.normal(size=1000)

--- a/jsk_rqt_plugins/src/jsk_rqt_plugins/hist.py
+++ b/jsk_rqt_plugins/src/jsk_rqt_plugins/hist.py
@@ -8,16 +8,15 @@ import sys
 from cStringIO import StringIO
 import cv2
 from cv_bridge import CvBridge
+from distutils.version import LooseVersion
 from matplotlib.figure import Figure
 import numpy as np
+import python_qt_binding
 from python_qt_binding import loadUi
 from python_qt_binding.QtCore import Qt
 from python_qt_binding.QtCore import QTimer
 from python_qt_binding.QtCore import Slot
 from python_qt_binding.QtGui import QIcon
-from python_qt_binding.QtGui import QSizePolicy
-from python_qt_binding.QtGui import QVBoxLayout
-from python_qt_binding.QtGui import QWidget
 import rospkg
 import rospy
 from rqt_gui_py.plugin import Plugin
@@ -27,6 +26,16 @@ from rqt_py_common.topic_completer import TopicCompleter
 from sensor_msgs.msg import Image
 
 from jsk_recognition_msgs.msg import HistogramWithRange
+
+# qt5 in kinetic
+if LooseVersion(python_qt_binding.QT_BINDING_VERSION).version[0] == 5:
+    from python_qt_binding.QtWidgets import QSizePolicy
+    from python_qt_binding.QtWidgets import QVBoxLayout
+    from python_qt_binding.QtWidgets import QWidget
+else:
+    from python_qt_binding.QtGui import QSizePolicy
+    from python_qt_binding.QtGui import QVBoxLayout
+    from python_qt_binding.QtGui import QWidget
 
 try:
     from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg \

--- a/jsk_rqt_plugins/src/jsk_rqt_plugins/hist.py
+++ b/jsk_rqt_plugins/src/jsk_rqt_plugins/hist.py
@@ -1,46 +1,49 @@
 #!/usr/bin/env python
-from rqt_gui_py.plugin import Plugin
-from python_qt_binding import loadUi
-from python_qt_binding.QtCore import Qt, QTimer, qWarning, Slot
-from python_qt_binding.QtGui import QAction, QIcon, QMenu, QWidget
-from python_qt_binding.QtGui import QWidget, QVBoxLayout, QSizePolicy, QColor
-from rqt_py_common.topic_completer import TopicCompleter
-from matplotlib.colors import colorConverter
-from rqt_py_common.topic_helpers import is_slot_numeric
-from rqt_plot.rosplot import ROSData as _ROSData
-from rqt_plot.rosplot import RosPlotException
-from matplotlib.collections import (PolyCollection, 
-                                    PathCollection, LineCollection)
-import matplotlib
-import matplotlib.patches as mpatches
-import rospkg
-import rospy
+
+import argparse
+import collections
+import os
+import sys
+
 from cStringIO import StringIO
 import cv2
 from cv_bridge import CvBridge
+from matplotlib.figure import Figure
+import numpy as np
+from python_qt_binding import loadUi
+from python_qt_binding.QtCore import Qt
+from python_qt_binding.QtCore import QTimer
+from python_qt_binding.QtCore import Slot
+from python_qt_binding.QtGui import QIcon
+from python_qt_binding.QtGui import QSizePolicy
+from python_qt_binding.QtGui import QVBoxLayout
+from python_qt_binding.QtGui import QWidget
+import rospkg
+import rospy
+from rqt_gui_py.plugin import Plugin
+from rqt_plot.rosplot import ROSData as _ROSData
+from rqt_plot.rosplot import RosPlotException
+from rqt_py_common.topic_completer import TopicCompleter
 from sensor_msgs.msg import Image
-from jsk_recognition_msgs.msg import HistogramWithRange, HistogramWithRangeBin
 
-import os, sys
-import argparse
-import collections
+from jsk_recognition_msgs.msg import HistogramWithRange
 
 try:
-    from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
+    from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg \
+        as FigureCanvas
 except ImportError:
     # work around bug in dateutil
-    import sys
     import thread
     sys.modules['_thread'] = thread
-    from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
+    from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg \
+        as FigureCanvas
 try:
-    from matplotlib.backends.backend_qt4agg import NavigationToolbar2QTAgg as NavigationToolbar
+    from matplotlib.backends.backend_qt4agg import NavigationToolbar2QTAgg \
+        as NavigationToolbar
 except ImportError:
-    from matplotlib.backends.backend_qt4agg import NavigationToolbar2QT as NavigationToolbar
-from matplotlib.figure import Figure
+    from matplotlib.backends.backend_qt4agg import NavigationToolbar2QT \
+        as NavigationToolbar
 
-import numpy as np
-import matplotlib.pyplot as plt
 
 class ROSData(_ROSData):
     def _get_data(self, msg):
@@ -52,10 +55,13 @@ class ROSData(_ROSData):
                 val = f(val)
             return val
         except IndexError:
-            self.error = RosPlotException("[%s] index error for: %s" % (self.name, str(val).replace('\n', ', ')))
+            self.error = RosPlotException(
+                "{0} index error for: {1}".format(
+                    self.name, str(val).replace('\n', ', ')))
         except TypeError:
-            self.error = RosPlotException("[%s] value was not numeric: %s" % (self.name, val))
-
+            self.error = RosPlotException(
+                "{0} value was not numeric: {1}".format(
+                    self.name, val))
 
 
 class HistogramPlot(Plugin):
@@ -65,23 +71,29 @@ class HistogramPlot(Plugin):
         self._args = self._parse_args(context.argv())
         self._widget = HistogramPlotWidget(self._args.topics)
         context.add_widget(self._widget)
+
     def _parse_args(self, argv):
-        parser = argparse.ArgumentParser(prog='rqt_histogram_plot', add_help=False)
+        parser = argparse.ArgumentParser(
+            prog='rqt_histogram_plot', add_help=False)
         HistogramPlot.add_arguments(parser)
         args = parser.parse_args(argv)
         return args
+
     @staticmethod
     def add_arguments(parser):
         group = parser.add_argument_group('Options for rqt_histogram plugin')
-        group.add_argument('topics', nargs='?', default=[], help='Topics to plot')
-        
+        group.add_argument(
+            'topics', nargs='?', default=[], help='Topics to plot')
+
+
 class HistogramPlotWidget(QWidget):
     _redraw_interval = 40
+
     def __init__(self, topics):
         super(HistogramPlotWidget, self).__init__()
         self.setObjectName('HistogramPlotWidget')
         rp = rospkg.RosPack()
-        ui_file = os.path.join(rp.get_path('jsk_rqt_plugins'), 
+        ui_file = os.path.join(rp.get_path('jsk_rqt_plugins'),
                                'resource', 'plot_histogram.ui')
         loadUi(ui_file, self)
         self.cv_bridge = CvBridge()
@@ -102,6 +114,7 @@ class HistogramPlotWidget(QWidget):
         self._update_plot_timer = QTimer(self)
         self._update_plot_timer.timeout.connect(self.update_plot)
         self._update_plot_timer.start(self._redraw_interval)
+
     @Slot('QDropEvent*')
     def dropEvent(self, event):
         if event.mimeData().hasText():
@@ -110,17 +123,20 @@ class HistogramPlotWidget(QWidget):
             droped_item = event.source().selectedItems()[0]
             topic_name = str(droped_item.data(0, Qt.UserRole))
         self.subscribe_topic(topic_name)
+
     @Slot()
     def on_topic_edit_returnPressed(self):
         if self.subscribe_topic_button.isEnabled():
             self.subscribe_topic(str(self.topic_edit.text()))
+
     @Slot()
     def on_subscribe_topic_button_clicked(self):
         self.subscribe_topic(str(self.topic_edit.text()))
 
     def subscribe_topic(self, topic_name):
         self.topic_with_field_name = topic_name
-        self.pub_image = rospy.Publisher(topic_name + "/histogram_image", Image)
+        self.pub_image = rospy.Publisher(
+            topic_name + "/histogram_image", Image)
         if not self._rosdata:
             self._rosdata = ROSData(topic_name, self._start_time)
         else:
@@ -130,12 +146,13 @@ class HistogramPlotWidget(QWidget):
                 self._rosdata = ROSData(topic_name, self._start_time)
             else:
                 rospy.logwarn("%s is already subscribed", topic_name)
-        
+
     def enable_timer(self, enabled=True):
         if enabled:
             self._update_plot_timer.start(self._redraw_interval)
         else:
             self._update_plot_timer.stop()
+
     @Slot()
     def on_clear_button_clicked(self):
         self.data_plot.clear()
@@ -171,7 +188,7 @@ class HistogramPlotWidget(QWidget):
                 % (self.topic_with_field_name,
                    self._rosdata.sub.data_class))
             return
-        #axes.xticks(range(5))
+        # axes.xticks(range(5))
         for p, x, w in zip(pos, xs, widths):
             axes.bar(p, x, color='r', align='center', width=w)
         axes.legend([self.topic_with_field_name], prop={'size': '8'})
@@ -182,6 +199,8 @@ class HistogramPlotWidget(QWidget):
         img_array = np.asarray(bytearray(buffer.read()), dtype=np.uint8)
         img = cv2.imdecode(img_array, cv2.CV_LOAD_IMAGE_COLOR)
         self.pub_image.publish(self.cv_bridge.cv2_to_imgmsg(img, "bgr8"))
+
+
 class MatHistogramPlot(QWidget):
     class Canvas(FigureCanvas):
         def __init__(self, parent=None):
@@ -190,9 +209,11 @@ class MatHistogramPlot(QWidget):
             self.figure.tight_layout()
             self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
             self.updateGeometry()
+
         def resizeEvent(self, event):
             super(MatHistogramPlot.Canvas, self).resizeEvent(event)
             self.figure.tight_layout()
+
     def __init__(self, parent=None):
         super(MatHistogramPlot, self).__init__(parent)
         self._canvas = MatHistogramPlot.Canvas()
@@ -201,8 +222,10 @@ class MatHistogramPlot(QWidget):
         vbox.addWidget(self._toolbar)
         vbox.addWidget(self._canvas)
         self.setLayout(vbox)
+
     def redraw(self):
         pass
+
     def clear(self):
         self._canvas.axes.cla()
         self._canvas.draw()

--- a/jsk_rqt_plugins/src/jsk_rqt_plugins/hist.py
+++ b/jsk_rqt_plugins/src/jsk_rqt_plugins/hist.py
@@ -145,7 +145,7 @@ class HistogramPlotWidget(QWidget):
     def subscribe_topic(self, topic_name):
         self.topic_with_field_name = topic_name
         self.pub_image = rospy.Publisher(
-            topic_name + "/histogram_image", Image)
+            topic_name + "/histogram_image", Image, queue_size=1)
         if not self._rosdata:
             self._rosdata = ROSData(topic_name, self._start_time)
         else:

--- a/jsk_rqt_plugins/src/jsk_rqt_plugins/hist.py
+++ b/jsk_rqt_plugins/src/jsk_rqt_plugins/hist.py
@@ -206,7 +206,11 @@ class HistogramPlotWidget(QWidget):
         self.data_plot._canvas.figure.savefig(buffer, format="png")
         buffer.seek(0)
         img_array = np.asarray(bytearray(buffer.read()), dtype=np.uint8)
-        img = cv2.imdecode(img_array, cv2.CV_LOAD_IMAGE_COLOR)
+        if LooseVersion(cv2.__version__).version[0] < 3:
+            iscolor = cv2.CV_LOAD_IMAGE_COLOR
+        else:
+            iscolor = cv2.IMREAD_COLOR
+        img = cv2.imdecode(img_array, iscolor)
         self.pub_image.publish(self.cv_bridge.cv2_to_imgmsg(img, "bgr8"))
 
 


### PR DESCRIPTION
`Kinetic` uses `qt5`, and `qt5` has different module structure.
I refactor codes and update to use correct module for kinetic.
You can check with
```
roslaunch jsk_perception sample_bof_object_recognition.launch
# or
roslaunch jsk_rqt_plugins sample_histogram.launch
```
![bof_histogram](https://user-images.githubusercontent.com/9300063/37442116-ef1ae62e-2847-11e8-9a77-1736a6fb9ab1.png)

