### PR TITLE
Add #include <boost/format.hpp>

### DIFF
--- a/jsk_rviz_plugins/src/tf_trajectory_display.cpp
+++ b/jsk_rviz_plugins/src/tf_trajectory_display.cpp
@@ -33,6 +33,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
+#include <boost/format.hpp>
 #include "tf_trajectory_display.h"
 
 namespace jsk_rviz_plugins


### PR DESCRIPTION
Same issue as https://github.com/jsk-ros-pkg/jsk_common/pull/1584

When building jsk_topic_tools on Ubuntu 18.04 with Ros Melodic and Boost 1.65.1.0ubuntu1 I get this error:
```
/home/laurenz/catkin_ws/src/jsk/jsk_rviz_plugins/src/tf_trajectory_display.cpp: In member function ‘virtu
al void jsk_rviz_plugins::TFTrajectoryDisplay::update(float, float)’:                                    
/home/laurenz/catkin_ws/src/jsk/jsk_rviz_plugins/src/tf_trajectory_display.cpp:136:25: error: ‘format’ is
 not a member of ‘boost’                                                                                 
                 (boost::format("Failed transforming from frame '%s' to frame '%s'")                     
                         ^~~~~~                                                                          
/home/laurenz/catkin_ws/src/jsk/jsk_rviz_plugins/src/tf_trajectory_display.cpp:136:25: note: suggested al
ternative: ‘forward’                                                                                     
                 (boost::format("Failed transforming from frame '%s' to frame '%s'")                     
                         ^~~~~~                                                                          
                         forward                                                                                                                        
```
which is easily fixed by including the appropriate include.  