### PR TITLE
jsk_rviz_plugins: warn on missing frame_id

### DIFF
--- a/jsk_rviz_plugins/src/bounding_box_display_common.h
+++ b/jsk_rviz_plugins/src/bounding_box_display_common.h
@@ -208,8 +208,12 @@ protected:
         Ogre::Quaternion orientation;
         if(!this->context_->getFrameManager()->transform(
             box.header, box.pose, position, orientation)) {
-          ROS_DEBUG("Error transforming from frame '%s' to frame '%s'",
-                  box.header.frame_id.c_str(), qPrintable(this->fixed_frame_));
+          std::ostringstream oss;
+          oss << "Error transforming pose";
+          oss << " from frame '" << box.header.frame_id << "'";
+          oss << " to frame '" << qPrintable(this->fixed_frame_) << "'";
+          ROS_ERROR_STREAM(oss.str());
+          this->setStatus(rviz::StatusProperty::Error, "Transform", QString::fromStdString(oss.str()));
           return;
         }
 
@@ -264,11 +268,13 @@ protected:
         if(!this->context_->getFrameManager()->transform(box.header, box.pose,
                                                   position,
                                                   quaternion)) {
-          ROS_ERROR( "Error transforming pose"
-                    "'%s' from frame '%s' to frame '%s'",
-                    qPrintable( this->getName() ), box.header.frame_id.c_str(),
-                    qPrintable( this->fixed_frame_ ));
-          return;                 // return?
+          std::ostringstream oss;
+          oss << "Error transforming pose";
+          oss << " from frame '" << box.header.frame_id << "'";
+          oss << " to frame '" << qPrintable(this->fixed_frame_) << "'";
+          ROS_ERROR_STREAM(oss.str());
+          this->setStatus(rviz::StatusProperty::Error, "Transform", QString::fromStdString(oss.str()));
+          return;
         }
         edge->setPosition(position);
         edge->setOrientation(quaternion);

--- a/jsk_rviz_plugins/src/footstep_display.cpp
+++ b/jsk_rviz_plugins/src/footstep_display.cpp
@@ -279,8 +279,12 @@ namespace jsk_rviz_plugins
     if(!context_->getFrameManager()->getTransform( msg->header.frame_id,
                                                     msg->header.stamp,
                                                    position, orientation)) {
-      ROS_DEBUG( "Error transforming from frame '%s' to frame '%s'",
-                 msg->header.frame_id.c_str(), qPrintable( fixed_frame_ ));
+      std::ostringstream oss;
+      oss << "Error transforming pose";
+      oss << " from frame '" << msg->header.frame_id << "'";
+      oss << " to frame '" << qPrintable(fixed_frame_) << "'";
+      ROS_ERROR_STREAM(oss.str());
+      setStatus(rviz::StatusProperty::Error, "Transform", QString::fromStdString(oss.str()));
       return;
     }
 
@@ -305,8 +309,12 @@ namespace jsk_rviz_plugins
                                                    step_position,
                                                    step_quaternion ))
       {
-        ROS_ERROR( "Error transforming pose '%s' from frame '%s' to frame '%s'",
-                   qPrintable( getName() ), msg->header.frame_id.c_str(), qPrintable( fixed_frame_ ));
+        std::ostringstream oss;
+        oss << "Error transforming pose";
+        oss << " from frame '" << msg->header.frame_id << "'";
+        oss << " to frame '" << qPrintable(fixed_frame_) << "'";
+        ROS_ERROR_STREAM(oss.str());
+        setStatus(rviz::StatusProperty::Error, "Transform", QString::fromStdString(oss.str()));
         return;
       }
       // add offset

--- a/jsk_rviz_plugins/src/people_position_measurement_array_display.cpp
+++ b/jsk_rviz_plugins/src/people_position_measurement_array_display.cpp
@@ -127,9 +127,12 @@ namespace jsk_rviz_plugins
                                                  pose,
                                                  position, orientation))
       {
-        ROS_DEBUG( "Error transforming from frame '%s' to frame '%s'",
-                   msg->header.frame_id.c_str(), qPrintable( fixed_frame_ ));
-        
+        std::ostringstream oss;
+        oss << "Error transforming pose";
+        oss << " from frame '" << msg->header.frame_id << "'";
+        oss << " to frame '" << qPrintable(fixed_frame_) << "'";
+        ROS_ERROR_STREAM(oss.str());
+        setStatus(rviz::StatusProperty::Error, "Transform", QString::fromStdString(oss.str()));
       }
       else {
         visualizers_[i]->setPosition(position);

--- a/jsk_rviz_plugins/src/polygon_array_display.cpp
+++ b/jsk_rviz_plugins/src/polygon_array_display.cpp
@@ -268,11 +268,8 @@ namespace jsk_rviz_plugins
     //Ogre::ManualObject* manual_object = manual_objects_[i];
     Ogre::Vector3 position;
     Ogre::Quaternion orientation;
-    if(!context_->getFrameManager()->getTransform(
-         polygon.header, position, orientation)) {
-      ROS_DEBUG("Error transforming from frame '%s' to frame '%s'",
-                 polygon.header.frame_id.c_str(), qPrintable(fixed_frame_));
-    }
+    if (!getTransform(polygon.header, position, orientation))
+      return;
     scene_node->setPosition(position);
     scene_node->setOrientation(orientation);
     rviz::BillboardLine* line = lines_[i];
@@ -320,12 +317,8 @@ namespace jsk_rviz_plugins
   {
     Ogre::Vector3 position;
     Ogre::Quaternion orientation;
-    if(!context_->getFrameManager()->getTransform(
-         polygon.header, position, orientation)) {
-      ROS_DEBUG("Error transforming from frame '%s' to frame '%s'",
-                 polygon.header.frame_id.c_str(), qPrintable(fixed_frame_));
+    if (!getTransform(polygon.header, position, orientation))
       return;
-    }
     
     {
       Ogre::SceneNode* scene_node = scene_nodes_[i * 2];
@@ -373,12 +366,8 @@ namespace jsk_rviz_plugins
     ArrowPtr arrow = arrow_objects_[i];
     Ogre::Vector3 position;
     Ogre::Quaternion orientation;
-    if(!context_->getFrameManager()->getTransform(
-         polygon.header, position, orientation)) {
-      ROS_DEBUG("Error transforming from frame '%s' to frame '%s'",
-                 polygon.header.frame_id.c_str(), qPrintable(fixed_frame_));
+    if (!getTransform(polygon.header, position, orientation))
       return;
-    }
     scene_node->setPosition(position);
     scene_node->setOrientation(orientation); // scene node is at frame pose
     jsk_recognition_utils::Polygon geo_polygon
@@ -459,6 +448,25 @@ namespace jsk_rviz_plugins
         processNormal(i, polygon);
       }
     }
+  }
+
+  bool PolygonArrayDisplay::getTransform(
+      const std_msgs::Header &header,
+      Ogre::Vector3 &position, Ogre::Quaternion &orientation)
+  {
+    bool ok = context_->getFrameManager()->getTransform(
+        header.frame_id, header.stamp,
+        position, orientation);
+    if (!ok) {
+      std::ostringstream oss;
+      oss << "Error transforming from frame '";
+      oss << header.frame_id << "' to frame '";
+      oss << qPrintable(fixed_frame_) << "'";
+      ROS_DEBUG_STREAM(oss.str());
+      setStatus(rviz::StatusProperty::Error,
+                "Transform", QString::fromStdString(oss.str()));
+    }
+    return ok;
   }
 
   void PolygonArrayDisplay::updateColoring()

--- a/jsk_rviz_plugins/src/polygon_array_display.h
+++ b/jsk_rviz_plugins/src/polygon_array_display.h
@@ -81,6 +81,9 @@ namespace jsk_rviz_plugins
     virtual void processPolygonMaterial(const size_t i);
     virtual void processMessage(
       const jsk_recognition_msgs::PolygonArray::ConstPtr& msg);
+    virtual bool getTransform(
+      const std_msgs::Header &header,
+      Ogre::Vector3& position, Ogre::Quaternion& orientation);
     rviz::ColorProperty* color_property_;
     rviz::FloatProperty* alpha_property_;
     rviz::BoolProperty* only_border_property_;

--- a/jsk_rviz_plugins/src/simple_occupancy_grid_array_display.cpp
+++ b/jsk_rviz_plugins/src/simple_occupancy_grid_array_display.cpp
@@ -125,10 +125,13 @@ namespace jsk_rviz_plugins
       if(!context_->getFrameManager()->transform(grid.header, plane_pose,
                                                  position,
                                                  quaternion)) {
-        ROS_ERROR( "Error transforming pose '%s' from frame '%s' to frame '%s'",
-                   qPrintable( getName() ), grid.header.frame_id.c_str(),
-                   qPrintable( fixed_frame_ ));
-        return;                 // return?
+        std::ostringstream oss;
+        oss << "Error transforming pose";
+        oss << " from frame '" << grid.header.frame_id << "'";
+        oss << " to frame '" << qPrintable(fixed_frame_) << "'";
+        ROS_ERROR_STREAM(oss.str());
+        setStatus(rviz::StatusProperty::Error, "Transform", QString::fromStdString(oss.str()));
+        return;
       }
       node->setPosition(position);
       node->setOrientation(quaternion);

--- a/jsk_rviz_plugins/src/target_visualizer_display.cpp
+++ b/jsk_rviz_plugins/src/target_visualizer_display.cpp
@@ -106,8 +106,12 @@ namespace jsk_rviz_plugins
                                                msg->pose,
                                                position, orientation))
     {
-      ROS_DEBUG( "Error transforming from frame '%s' to frame '%s'",
-                 msg->header.frame_id.c_str(), qPrintable( fixed_frame_ ));
+      std::ostringstream oss;
+      oss << "Error transforming pose";
+      oss << " from frame '" << msg->header.frame_id << "'";
+      oss << " to frame '" << qPrintable(fixed_frame_) << "'";
+      ROS_ERROR_STREAM(oss.str());
+      setStatus(rviz::StatusProperty::Error, "Transform", QString::fromStdString(oss.str()));
       return;
     }
     visualizer_->setPosition(position);

--- a/jsk_rviz_plugins/src/torus_array_display.cpp
+++ b/jsk_rviz_plugins/src/torus_array_display.cpp
@@ -267,12 +267,15 @@ namespace jsk_rviz_plugins
       if(!context_->getFrameManager()->transform(torus.header, torus.pose,
                                                  position,
                                                  quaternion))
-        {
-          ROS_ERROR( "Error transforming pose '%s' from frame '%s' to frame '%s'",
-                     qPrintable( getName() ), torus.header.frame_id.c_str(),
-                     qPrintable( fixed_frame_ ));
+      {
+          std::ostringstream oss;
+          oss << "Error transforming pose";
+          oss << " from frame '" << torus.header.frame_id << "'";
+          oss << " to frame '" << qPrintable(fixed_frame_) << "'";
+          ROS_ERROR_STREAM(oss.str());
+          setStatus(rviz::StatusProperty::Error, "Transform", QString::fromStdString(oss.str()));
           return;
-        }
+      }
 
       shape->clear();
       std::vector<Triangle> triangles;


### PR DESCRIPTION
Closes #697 
In this PR, a warning is displayed when received messages are not valid.

![polygons](https://user-images.githubusercontent.com/1901008/41752261-5ec61096-7601-11e8-9781-e81adddba092.png)
