### PR TITLE
[jsk_rviz_plugins] use QScreen::grabWindow() instead of QPixmap::grabWindow

### DIFF
--- a/jsk_rviz_plugins/src/video_capture_display.cpp
+++ b/jsk_rviz_plugins/src/video_capture_display.cpp
@@ -40,6 +40,10 @@
 #include <rviz/display.h>
 #include <rviz/render_panel.h>
 #include <QImage>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+#include <QScreen>
+#include <QGuiApplication>
+#endif
 #include <boost/filesystem.hpp>
 
 namespace jsk_rviz_plugins
@@ -169,8 +173,13 @@ namespace jsk_rviz_plugins
     }
     if (capturing_) {
       rviz::RenderPanel* panel = context_->getViewManager()->getRenderPanel();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+      QPixmap screenshot
+        = QGuiApplication::primaryScreen()->grabWindow(context_->getViewManager()->getRenderPanel()->winId());
+#else
       QPixmap screenshot
         = QPixmap::grabWindow(context_->getViewManager()->getRenderPanel()->winId());
+#endif
       QImage src = screenshot.toImage().convertToFormat(QImage::Format_RGB888);  // RGB
       cv::Mat image(src.height(), src.width(), CV_8UC3,
                     (uchar*)src.bits(), src.bytesPerLine());  // RGB


### PR DESCRIPTION
Hi,

When I use ``VideoCapture`` plugin on Kinetic/Xenial, lots of warnings are displayed.

```
[ INFO] [1531911783.631987034]: output.avi do not exists
[ INFO] [1531911783.632022863]: dirname: .
[ WARN] [1531911783.671459216]: force to disable capturing
[ INFO] [1531911788.681274189]: updateStartCapture
[ INFO] [1531911788.681339840]: start capturing
static QPixmap QPixmap::grabWindow(WId, int, int, int, int) is deprecated, use QScreen::grabWindow() instead. Defaulting to primary screen.
static QPixmap QPixmap::grabWindow(WId, int, int, int, int) is deprecated, use QScreen::grabWindow() instead. Defaulting to primary screen.
static QPixmap QPixmap::grabWindow(WId, int, int, int, int) is deprecated, use QScreen::grabWindow() instead. Defaulting to primary screen.
static QPixmap QPixmap::grabWindow(WId, int, int, int, int) is deprecated, use QScreen::grabWindow() instead. Defaulting to primary screen.
static QPixmap QPixmap::grabWindow(WId, int, int, int, int) is deprecated, use QScreen::grabWindow() instead. Defaulting to primary screen.
static QPixmap QPixmap::grabWindow(WId, int, int, int, int) is deprecated, use QScreen::grabWindow() instead. Defaulting to primary screen.
static QPixmap QPixmap::grabWindow(WId, int, int, int, int) is deprecated, use QScreen::grabWindow() instead. Defaulting to primary screen.
```

This is because ``QPixmap::grabWindow`` is deprecated since Qt5.
http://doc.qt.io/qt-5/qpixmap-obsolete.html

I replaced ``QPixmap::grabWindow`` with ``QScreen::grabWindow()``.

Thanks.