### PR TITLE
[jsk_rqt_plugins] Add dependency of sklearn

### DIFF
--- a/jsk_rqt_plugins/package.xml
+++ b/jsk_rqt_plugins/package.xml
@@ -28,6 +28,7 @@
   <run_depend version_gte="4.3.0" >jsk_gui_msgs</run_depend>
   <run_depend>cv_bridge</run_depend>
   <run_depend>python-urlgrabber</run_depend>
+  <run_depend>python-sklearn</run_depend>
   <run_depend>message_runtime</run_depend>
   <export>
     <rqt_gui plugin="${prefix}/plugin.xml" />


### PR DESCRIPTION
In plot_2d.py, sklearn is used.
https://github.com/jsk-ros-pkg/jsk_visualization/blob/master/jsk_rqt_plugins/src/jsk_rqt_plugins/plot_2d.py#L24
