### PR TITLE
[jsk_interactive_markers] Remove newline and leading spaces from package.xml

### DIFF
--- a/jsk_interactive_markers/jsk_interactive_marker/package.xml
+++ b/jsk_interactive_markers/jsk_interactive_marker/package.xml
@@ -1,10 +1,6 @@
 <package>
-  <name>
-    jsk_interactive_marker
-  </name>
-  <description>
-    jsk interactive markers
-  </description>
+  <name>jsk_interactive_marker</name>
+  <description>jsk interactive markers</description>
   <version>2.1.3</version>
   <author email="furuta@jsk.t.u-tokyo.ac.jp">furuta</author>
   <maintainer email="furuta@jsk.t.u-tokyo.ac.jp">furuta</maintainer>


### PR DESCRIPTION
## Environment

* Ubuntu 16.04
* ROS lunar
* jsk_visualization 79dcedf7fd761fc638f1cffc1cfaa46a7bb4f1a2

## Problem

I've ran into an issue where rviz output the following error message:

```
[ERROR] [/rviz] [1536118616.536662095]: Skipped loading plugin with error: XML Document '   jsk_interactive_marker' has no Root Element. This likely means the XML is malformed or missing..
[ERROR] [/rviz] [1536118616.536795297]: Skipped loading plugin with error: XML Document '  /home/naoki/ros/workspaces/lunar/common/src/jsk_visualization/jsk_interactive_markers/jsk_interactive_marker/plugin_description.xml' has no Root Element. This likely means the XML is malformed or missing..
```

Notice the leading spaces before the path.

Running `rospack plugins --attrib=plugin rviz`, I got:

```
moveit_ros_visualization /opt/ros/lunar/share/moveit_ros_visualization/robot_state_rviz_plugin_description.xml
moveit_ros_visualization /opt/ros/lunar/share/moveit_ros_visualization/planning_scene_rviz_plugin_description.xml
moveit_ros_visualization /opt/ros/lunar/share/moveit_ros_visualization/motion_planning_rviz_plugin_description.xml
moveit_ros_visualization /opt/ros/lunar/share/moveit_ros_visualization/trajectory_rviz_plugin_description.xml
rviz_plugin_tutorials /opt/ros/lunar/share/rviz_plugin_tutorials/plugin_description.xml
rviz_visual_tools /opt/ros/lunar/share/rviz_visual_tools/plugin_description.xml
jsk_rviz_plugins /home/naoki/ros/workspaces/lunar/common/src/jsk_visualization/jsk_rviz_plugins/plugin_description.xml

    jsk_interactive_marker
   /home/naoki/ros/workspaces/lunar/common/src/jsk_visualization/jsk_interactive_markers/jsk_interactive_marker/plugin_description.xml
grid_map_rviz_plugin /home/naoki/ros/workspaces/lunar/common/src/grid_map/grid_map_rviz_plugin/plugin_description.xml
rviz /home/naoki/ros/workspaces/lunar/common/src/rviz/plugin_description.xml
```

There's still the strange newline and leading spaces for `jsk_interactive_marker`. Further investigating this issue I found the probable cause of this problem [here](https://github.com/jsk-ros-pkg/jsk_visualization/blob/79dcedf7fd761fc638f1cffc1cfaa46a7bb4f1a2/jsk_interactive_markers/jsk_interactive_marker/package.xml#L2-L4).

Applying the change in this PR, I get the correct output as follows:

```
jsk_interactive_marker /home/naoki/ros/workspaces/lunar/common/src/jsk_visualization/jsk_interactive_markers/jsk_interactive_marker/plugin_description.xml
grid_map_rviz_plugin /home/naoki/ros/workspaces/lunar/common/src/grid_map/grid_map_rviz_plugin/plugin_description.xml
jsk_rviz_plugins /home/naoki/ros/workspaces/lunar/common/src/jsk_visualization/jsk_rviz_plugins/plugin_description.xml
rviz_visual_tools /opt/ros/lunar/share/rviz_visual_tools/plugin_description.xml
rviz_plugin_tutorials /opt/ros/lunar/share/rviz_plugin_tutorials/plugin_description.xml
moveit_ros_visualization /opt/ros/lunar/share/moveit_ros_visualization/robot_state_rviz_plugin_description.xml
moveit_ros_visualization /opt/ros/lunar/share/moveit_ros_visualization/planning_scene_rviz_plugin_description.xml
moveit_ros_visualization /opt/ros/lunar/share/moveit_ros_visualization/motion_planning_rviz_plugin_description.xml
moveit_ros_visualization /opt/ros/lunar/share/moveit_ros_visualization/trajectory_rviz_plugin_description.xml
rviz /home/naoki/ros/workspaces/lunar/common/src/rviz/plugin_description.xml
```

Even though I'm not sure whether this problem only happens in my environment (since `git blame` tells me the snippet has been there for quite a while), I think it's better to match the format with the other packages in the repository e.g. [jsk_rviz_plugins](https://github.com/jsk-ros-pkg/jsk_visualization/blob/79dcedf7fd761fc638f1cffc1cfaa46a7bb4f1a2/jsk_rviz_plugins/package.xml#L3), [jsk_rqt_plugins](https://github.com/jsk-ros-pkg/jsk_visualization/blob/79dcedf7fd761fc638f1cffc1cfaa46a7bb4f1a2/jsk_rqt_plugins/package.xml#L3).