### PR TITLE
replace boost::shared_ptr by std::shared_ptr

### DIFF
--- a/jsk_interactive_markers/jsk_interactive_marker/CMakeLists.txt
+++ b/jsk_interactive_markers/jsk_interactive_marker/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(jsk_interactive_marker)
 
+add_compile_options(-std=c++11)
 
 # Use ccache if installed to make it fast to generate object files
 find_program(CCACHE_FOUND ccache)

--- a/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/camera_info_publisher.h
+++ b/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/camera_info_publisher.h
@@ -49,7 +49,7 @@ namespace jsk_interactive_marker
   class CameraInfoPublisher
   {
   public:
-    typedef boost::shared_ptr<CameraInfoPublisher> Ptr;
+    typedef std::shared_ptr<CameraInfoPublisher> Ptr;
     typedef jsk_interactive_marker::CameraInfoPublisherConfig Config;
     CameraInfoPublisher();
     virtual ~CameraInfoPublisher();
@@ -75,10 +75,10 @@ namespace jsk_interactive_marker
     ros::Publisher pub_camera_info_;
     ros::Subscriber sub_sync_;
     ros::Timer timer_;
-    boost::shared_ptr <dynamic_reconfigure::Server<Config> > srv_;
+    std::shared_ptr <dynamic_reconfigure::Server<Config> > srv_;
     boost::mutex mutex_;
-    boost::shared_ptr<interactive_markers::InteractiveMarkerServer> server_;
-    boost::shared_ptr<tf::TransformListener> tf_listener_;
+    std::shared_ptr<interactive_markers::InteractiveMarkerServer> server_;
+    std::shared_ptr<tf::TransformListener> tf_listener_;
     ////////////////////////////////////////////////////////
     // variables
     ////////////////////////////////////////////////////////

--- a/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/door_foot.h
+++ b/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/door_foot.h
@@ -35,7 +35,7 @@ class DoorFoot{
   int footstep_index_;
   ros::NodeHandle nh_;
   ros::NodeHandle pnh_;
-  boost::shared_ptr<interactive_markers::InteractiveMarkerServer> server_;
+  std::shared_ptr<interactive_markers::InteractiveMarkerServer> server_;
 
   std::string server_name;
   std::string marker_name;

--- a/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/footstep_marker.h
+++ b/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/footstep_marker.h
@@ -97,7 +97,7 @@ protected:
   bool forceToReplan(std_srvs::Empty::Request& req, std_srvs::Empty::Request& res);
   boost::mutex plane_mutex_;
   boost::mutex plan_run_mutex_;
-  boost::shared_ptr<dynamic_reconfigure::Server<Config> > srv_;
+  std::shared_ptr<dynamic_reconfigure::Server<Config> > srv_;
   // projection to the planes
   bool projectMarkerToPlane();
   
@@ -118,7 +118,7 @@ protected:
 
   visualization_msgs::Marker makeFootstepMarker(geometry_msgs::Pose pose);
   
-  boost::shared_ptr<interactive_markers::InteractiveMarkerServer> server_;
+  std::shared_ptr<interactive_markers::InteractiveMarkerServer> server_;
   interactive_markers::MenuHandler menu_handler_;
   double foot_size_x_;
   double foot_size_y_;
@@ -138,7 +138,7 @@ protected:
   ros::ServiceClient snapit_client_;
   ros::ServiceClient estimate_occlusion_client_;
   ros::ServiceServer plan_if_possible_srv_;
-  boost::shared_ptr<tf::TransformListener> tf_listener_;
+  std::shared_ptr<tf::TransformListener> tf_listener_;
   PlanningActionClient ac_;
   ExecuteActionClient ac_exec_;
   bool use_projection_service_;

--- a/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/interactive_marker_interface.h
+++ b/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/interactive_marker_interface.h
@@ -28,7 +28,7 @@ class InteractiveMarkerInterface {
   };
 
   struct UrdfProperty{
-    std::shared_ptr<urdf::ModelInterface> model;
+    urdf::ModelInterfaceSharedPtr model;
     std::string root_link_name;
     geometry_msgs::Pose pose;
     double scale;

--- a/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/interactive_marker_interface.h
+++ b/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/interactive_marker_interface.h
@@ -16,7 +16,13 @@
 
 #include <std_msgs/Int8.h>
 #include "urdf_parser/urdf_parser.h"
+#if ROS_VERSION_MINIMUM(1,12,0) // kinetic
 #include <urdf_world/types.h>
+#else
+namespace urdf {
+typedef boost::shared_ptr<ModelInterface> ModelInterfaceSharedPtr;
+}
+#endif
 
 class InteractiveMarkerInterface {
  private:

--- a/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/interactive_marker_interface.h
+++ b/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/interactive_marker_interface.h
@@ -16,6 +16,7 @@
 
 #include <std_msgs/Int8.h>
 #include "urdf_parser/urdf_parser.h"
+#include <urdf_world/types.h>
 
 class InteractiveMarkerInterface {
  private:

--- a/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/interactive_marker_interface.h
+++ b/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/interactive_marker_interface.h
@@ -28,7 +28,7 @@ class InteractiveMarkerInterface {
   };
 
   struct UrdfProperty{
-    boost::shared_ptr<urdf::ModelInterface> model;
+    std::shared_ptr<urdf::ModelInterface> model;
     std::string root_link_name;
     geometry_msgs::Pose pose;
     double scale;
@@ -147,7 +147,7 @@ class InteractiveMarkerInterface {
 
   ros::NodeHandle nh_;
   ros::NodeHandle pnh_;
-  boost::shared_ptr<interactive_markers::InteractiveMarkerServer> server_;
+  std::shared_ptr<interactive_markers::InteractiveMarkerServer> server_;
   ros::Publisher pub_;
   ros::Publisher pub_update_;
   ros::Publisher pub_move_;

--- a/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/interactive_marker_utils.h
+++ b/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/interactive_marker_utils.h
@@ -25,8 +25,21 @@
 #include <kdl/frames_io.hpp>
 #include <tf_conversions/tf_kdl.h>
 
+#if ROS_VERSION_MINIMUM(1,12,0) // kinetic
 #include <urdf_model/types.h>
 #include <urdf_world/types.h>
+#else
+namespace urdf {
+typedef boost::shared_ptr<ModelInterface> ModelInterfaceSharedPtr;
+typedef boost::shared_ptr<Link> LinkSharedPtr;
+typedef boost::shared_ptr<const Link> LinkConstSharedPtr;
+typedef boost::shared_ptr<Visual> VisualSharedPtr;
+typedef boost::shared_ptr<const Mesh> MeshConstSharedPtr;
+typedef boost::shared_ptr<const Cylinder> CylinderConstSharedPtr;
+typedef boost::shared_ptr<const Box> BoxConstSharedPtr;
+typedef boost::shared_ptr<const Sphere> SphereConstSharedPtr;
+}
+#endif
 
 
 using namespace urdf;

--- a/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/interactive_marker_utils.h
+++ b/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/interactive_marker_utils.h
@@ -25,6 +25,9 @@
 #include <kdl/frames_io.hpp>
 #include <tf_conversions/tf_kdl.h>
 
+#include <urdf_model/types.h>
+#include <urdf_world/types.h>
+
 
 using namespace urdf;
 

--- a/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/interactive_marker_utils.h
+++ b/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/interactive_marker_utils.h
@@ -40,11 +40,11 @@ namespace im_utils{
   visualization_msgs::InteractiveMarkerControl makeMeshMarkerControl(const std::string &mesh_resource, const geometry_msgs::PoseStamped &stamped, geometry_msgs::Vector3 scale);
   visualization_msgs::InteractiveMarkerControl makeMeshMarkerControl(const std::string &mesh_resource,
                                                                      const geometry_msgs::PoseStamped &stamped, geometry_msgs::Vector3 scale, const std_msgs::ColorRGBA &color);
-  void addMeshLinksControl(visualization_msgs::InteractiveMarker &im, std::shared_ptr<const Link> link, KDL::Frame previous_frame, bool use_color, std_msgs::ColorRGBA color, double scale);
-  void addMeshLinksControl(visualization_msgs::InteractiveMarker &im, std::shared_ptr<const Link> link, KDL::Frame previous_frame, bool use_color, std_msgs::ColorRGBA color, double scale, bool root);
+  void addMeshLinksControl(visualization_msgs::InteractiveMarker &im, LinkConstSharedPtr link, KDL::Frame previous_frame, bool use_color, std_msgs::ColorRGBA color, double scale);
+  void addMeshLinksControl(visualization_msgs::InteractiveMarker &im, LinkConstSharedPtr link, KDL::Frame previous_frame, bool use_color, std_msgs::ColorRGBA color, double scale, bool root);
 
-  std::shared_ptr<ModelInterface> getModelInterface(std::string model_file);
-  visualization_msgs::InteractiveMarker makeLinksMarker(std::shared_ptr<const Link> link, bool use_color, std_msgs::ColorRGBA color, geometry_msgs::PoseStamped marker_ps, geometry_msgs::Pose origin_pose);
+  ModelInterfaceSharedPtr getModelInterface(std::string model_file);
+  visualization_msgs::InteractiveMarker makeLinksMarker(LinkConstSharedPtr link, bool use_color, std_msgs::ColorRGBA color, geometry_msgs::PoseStamped marker_ps, geometry_msgs::Pose origin_pose);
 
   visualization_msgs::InteractiveMarker makeFingerControlMarker(const char *name, geometry_msgs::PoseStamped ps);
   visualization_msgs::InteractiveMarker makeSandiaHandMarker(geometry_msgs::PoseStamped ps);

--- a/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/interactive_marker_utils.h
+++ b/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/interactive_marker_utils.h
@@ -40,11 +40,11 @@ namespace im_utils{
   visualization_msgs::InteractiveMarkerControl makeMeshMarkerControl(const std::string &mesh_resource, const geometry_msgs::PoseStamped &stamped, geometry_msgs::Vector3 scale);
   visualization_msgs::InteractiveMarkerControl makeMeshMarkerControl(const std::string &mesh_resource,
                                                                      const geometry_msgs::PoseStamped &stamped, geometry_msgs::Vector3 scale, const std_msgs::ColorRGBA &color);
-  void addMeshLinksControl(visualization_msgs::InteractiveMarker &im, boost::shared_ptr<const Link> link, KDL::Frame previous_frame, bool use_color, std_msgs::ColorRGBA color, double scale);
-  void addMeshLinksControl(visualization_msgs::InteractiveMarker &im, boost::shared_ptr<const Link> link, KDL::Frame previous_frame, bool use_color, std_msgs::ColorRGBA color, double scale, bool root);
+  void addMeshLinksControl(visualization_msgs::InteractiveMarker &im, std::shared_ptr<const Link> link, KDL::Frame previous_frame, bool use_color, std_msgs::ColorRGBA color, double scale);
+  void addMeshLinksControl(visualization_msgs::InteractiveMarker &im, std::shared_ptr<const Link> link, KDL::Frame previous_frame, bool use_color, std_msgs::ColorRGBA color, double scale, bool root);
 
-  boost::shared_ptr<ModelInterface> getModelInterface(std::string model_file);
-  visualization_msgs::InteractiveMarker makeLinksMarker(boost::shared_ptr<const Link> link, bool use_color, std_msgs::ColorRGBA color, geometry_msgs::PoseStamped marker_ps, geometry_msgs::Pose origin_pose);
+  std::shared_ptr<ModelInterface> getModelInterface(std::string model_file);
+  visualization_msgs::InteractiveMarker makeLinksMarker(std::shared_ptr<const Link> link, bool use_color, std_msgs::ColorRGBA color, geometry_msgs::PoseStamped marker_ps, geometry_msgs::Pose origin_pose);
 
   visualization_msgs::InteractiveMarker makeFingerControlMarker(const char *name, geometry_msgs::PoseStamped ps);
   visualization_msgs::InteractiveMarker makeSandiaHandMarker(geometry_msgs::PoseStamped ps);

--- a/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/interactive_point_cloud.h
+++ b/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/interactive_point_cloud.h
@@ -51,7 +51,7 @@ public:
 private:
 
   typedef jsk_interactive_marker::InteractivePointCloudConfig Config;
-  boost::shared_ptr <dynamic_reconfigure::Server<Config> > srv_;
+  std::shared_ptr <dynamic_reconfigure::Server<Config> > srv_;
   boost::mutex mutex_;
   virtual void configCallback (Config &config, uint32_t level);
 
@@ -95,8 +95,8 @@ private:
   message_filters::Subscriber<jsk_recognition_msgs::Int32Stamped> sub_selected_index_;
   message_filters::Subscriber<geometry_msgs::PoseArray> sub_handle_array_;
   tf::TransformListener tfl_;
-  boost::shared_ptr<message_filters::Synchronizer<SyncPolicy> >sync_;
-  boost::shared_ptr<message_filters::Synchronizer<SyncHandlePose> > sync_handle_;
+  std::shared_ptr<message_filters::Synchronizer<SyncPolicy> >sync_;
+  std::shared_ptr<message_filters::Synchronizer<SyncHandlePose> > sync_handle_;
   
   jsk_interactive_marker::ParentAndChildInteractiveMarkerServer marker_server_;
   interactive_markers::MenuHandler menu_handler_;

--- a/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/parent_and_child_interactive_marker_server.h
+++ b/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/parent_and_child_interactive_marker_server.h
@@ -71,7 +71,7 @@ namespace jsk_interactive_marker
     // access: parent server -> subscriber
     std::map <std::string, ros::Subscriber> parent_update_subscribers_; // self association is not included
     std::map <std::string, ros::Subscriber> parent_feedback_subscribers_; // self association is not included
-    std::map <std::string, boost::shared_ptr <FeedbackSynthesizer> > callback_map_;
+    std::map <std::string, std::shared_ptr <FeedbackSynthesizer> > callback_map_;
     std::map <std::string, int> parent_subscriber_nums_;
   };
 }

--- a/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/point_cloud_config_marker.h
+++ b/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/point_cloud_config_marker.h
@@ -56,7 +56,7 @@ class PointCloudConfigMarker{
  private:
   ros::NodeHandle nh_;
   ros::NodeHandle pnh_;
-  boost::shared_ptr<interactive_markers::InteractiveMarkerServer> server_;
+  std::shared_ptr<interactive_markers::InteractiveMarkerServer> server_;
   visualization_msgs::InteractiveMarkerFeedbackConstPtr latest_feedback_;
   ros::Publisher pub_;
   ros::Publisher current_pose_pub_;

--- a/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/pointcloud_cropper.h
+++ b/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/pointcloud_cropper.h
@@ -61,7 +61,7 @@ namespace jsk_interactive_marker
   class Cropper
   {
   public:
-    typedef boost::shared_ptr<Cropper> Ptr;
+    typedef std::shared_ptr<Cropper> Ptr;
     Cropper(const unsigned int nr_parameter);
     virtual ~Cropper();
     
@@ -87,7 +87,7 @@ namespace jsk_interactive_marker
   class SphereCropper: public Cropper
   {
   public:
-    typedef boost::shared_ptr<SphereCropper> Ptr;
+    typedef std::shared_ptr<SphereCropper> Ptr;
     
     SphereCropper();
     virtual ~SphereCropper();
@@ -104,7 +104,7 @@ namespace jsk_interactive_marker
   class CubeCropper: public Cropper
   {
   public:
-    typedef boost::shared_ptr<CubeCropper> Ptr;
+    typedef std::shared_ptr<CubeCropper> Ptr;
     
     CubeCropper();
     virtual ~CubeCropper();
@@ -151,15 +151,15 @@ namespace jsk_interactive_marker
     ros::Subscriber point_sub_;
     ros::Publisher point_pub_;
     ros::Publisher point_visualization_pub_;
-    boost::shared_ptr<interactive_markers::InteractiveMarkerServer> server_;
+    std::shared_ptr<interactive_markers::InteractiveMarkerServer> server_;
     //pcl::PointCloud<pcl::PointXYZ>::Ptr latest_pointcloud_;
     sensor_msgs::PointCloud2::ConstPtr latest_pointcloud_;
-    boost::shared_ptr <dynamic_reconfigure::Server<Config> > srv_;
+    std::shared_ptr <dynamic_reconfigure::Server<Config> > srv_;
     interactive_markers::MenuHandler menu_handler_;
     Cropper::Ptr cropper_;
     std::vector<Cropper::Ptr> cropper_candidates_;
     EntryHandleVector cropper_entries_;
-    boost::shared_ptr<tf::TransformListener> tf_listener_;
+    std::shared_ptr<tf::TransformListener> tf_listener_;
     
   private:
   };

--- a/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/transformable_interactive_server.h
+++ b/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/transformable_interactive_server.h
@@ -135,7 +135,7 @@ namespace jsk_interactive_marker
     ros::Publisher marker_dimensions_pub_;
     ros::ServiceServer request_marker_operate_srv_;
 
-    boost::shared_ptr <dynamic_reconfigure::Server<InteractiveSettingConfig> > config_srv_;
+    std::shared_ptr <dynamic_reconfigure::Server<InteractiveSettingConfig> > config_srv_;
 
     ros::Subscriber setrad_sub_;
     ros::Publisher focus_name_text_pub_;
@@ -145,14 +145,14 @@ namespace jsk_interactive_marker
     ros::Publisher pose_with_name_pub_;
     interactive_markers::InteractiveMarkerServer* server_;
     map<string, TransformableObject*> transformable_objects_map_;
-    boost::shared_ptr<tf::TransformListener> tf_listener_;
+    std::shared_ptr<tf::TransformListener> tf_listener_;
     int torus_udiv_;
     int torus_vdiv_;
     jsk_interactive_marker::InteractiveSettingConfig config_;
     bool strict_tf_;
     int interactive_manipulator_orientation_;
     ros::Timer tf_timer;
-    boost::shared_ptr <YamlMenuHandler> yaml_menu_handler_ptr_;
+    std::shared_ptr <YamlMenuHandler> yaml_menu_handler_ptr_;
   };
 }
 

--- a/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/triangle_foot.h
+++ b/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/triangle_foot.h
@@ -22,7 +22,7 @@ class TriangleFoot{
  private:
   ros::NodeHandle nh_;
   ros::NodeHandle pnh_;
-  boost::shared_ptr<interactive_markers::InteractiveMarkerServer> server_;
+  std::shared_ptr<interactive_markers::InteractiveMarkerServer> server_;
 
   std::string server_name;
   std::string marker_name;

--- a/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/urdf_model_marker.h
+++ b/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/urdf_model_marker.h
@@ -43,12 +43,12 @@ using namespace std;
 class UrdfModelMarker {
  public:
   //  UrdfModelMarker(string file);
-  UrdfModelMarker(string file, boost::shared_ptr<interactive_markers::InteractiveMarkerServer> server);
-  UrdfModelMarker(string model_name, string model_description, string model_file, string frame_id, geometry_msgs::PoseStamped  root_pose, geometry_msgs::Pose root_offset, double scale_factor, string mode, bool robot_mode, bool registration, vector<string> fixed_link, bool use_robot_description, bool use_visible_color, map<string, double> initial_pose_map, int index, boost::shared_ptr<interactive_markers::InteractiveMarkerServer> server);
+  UrdfModelMarker(string file, std::shared_ptr<interactive_markers::InteractiveMarkerServer> server);
+  UrdfModelMarker(string model_name, string model_description, string model_file, string frame_id, geometry_msgs::PoseStamped  root_pose, geometry_msgs::Pose root_offset, double scale_factor, string mode, bool robot_mode, bool registration, vector<string> fixed_link, bool use_robot_description, bool use_visible_color, map<string, double> initial_pose_map, int index, std::shared_ptr<interactive_markers::InteractiveMarkerServer> server);
   UrdfModelMarker();
 
-  void addMoveMarkerControl(visualization_msgs::InteractiveMarker &int_marker, boost::shared_ptr<const Link> link, bool root);
-  void addInvisibleMeshMarkerControl(visualization_msgs::InteractiveMarker &int_marker, boost::shared_ptr<const Link> link, const std_msgs::ColorRGBA &color);
+  void addMoveMarkerControl(visualization_msgs::InteractiveMarker &int_marker, std::shared_ptr<const Link> link, bool root);
+  void addInvisibleMeshMarkerControl(visualization_msgs::InteractiveMarker &int_marker, std::shared_ptr<const Link> link, const std_msgs::ColorRGBA &color);
   void addGraspPointControl(visualization_msgs::InteractiveMarker &int_marker, std::string link_frame_name_);
 
   void publishBasePose( const visualization_msgs::InteractiveMarkerFeedbackConstPtr &feedback );
@@ -85,15 +85,15 @@ class UrdfModelMarker {
   //joint state methods
   void publishJointState();
   void getJointState();
-  void getJointState(boost::shared_ptr<const Link> link);
+  void getJointState(std::shared_ptr<const Link> link);
 
-  void setJointState(boost::shared_ptr<const Link> link, const sensor_msgs::JointStateConstPtr &js);
-  void setJointAngle(boost::shared_ptr<const Link> link, double joint_angle);
+  void setJointState(std::shared_ptr<const Link> link, const sensor_msgs::JointStateConstPtr &js);
+  void setJointAngle(std::shared_ptr<const Link> link, double joint_angle);
   geometry_msgs::Pose getRootPose(geometry_msgs::Pose pose);
   geometry_msgs::PoseStamped getOriginPoseStamped();
-  void setOriginalPose(boost::shared_ptr<const Link> link);
-  void addChildLinkNames(boost::shared_ptr<const Link> link, bool root, bool init);
-  void addChildLinkNames(boost::shared_ptr<const Link> link, bool root, bool init, bool use_color, int color_index);
+  void setOriginalPose(std::shared_ptr<const Link> link);
+  void addChildLinkNames(std::shared_ptr<const Link> link, bool root, bool init);
+  void addChildLinkNames(std::shared_ptr<const Link> link, bool root, bool init, bool use_color, int color_index);
 
   void callSetDynamicTf(string parent_frame_id, string frame_id, geometry_msgs::Transform transform);
   void callPublishTf();
@@ -123,10 +123,10 @@ class UrdfModelMarker {
  protected:
   ros::NodeHandle nh_;
   ros::NodeHandle pnh_;
-  boost::shared_ptr<interactive_markers::InteractiveMarkerServer> server_;
+  std::shared_ptr<interactive_markers::InteractiveMarkerServer> server_;
   
   /* diagnostics */
-  boost::shared_ptr<diagnostic_updater::Updater> diagnostic_updater_;
+  std::shared_ptr<diagnostic_updater::Updater> diagnostic_updater_;
   jsk_topic_tools::TimeAccumulator reset_joint_states_check_time_acc_;
   jsk_topic_tools::TimeAccumulator dynamic_tf_check_time_acc_;
 
@@ -170,7 +170,7 @@ class UrdfModelMarker {
   std::string target_frame;
 
 
-  boost::shared_ptr<ModelInterface> model;
+  std::shared_ptr<ModelInterface> model;
   std::string model_name_;
   std::string model_description_;
   std::string frame_id_;

--- a/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/urdf_model_marker.h
+++ b/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/urdf_model_marker.h
@@ -36,8 +36,16 @@
 
 #include <jsk_topic_tools/time_accumulator.h>
 
+#if ROS_VERSION_MINIMUM(1,12,0) // kinetic
 #include <urdf_model/types.h>
 #include <urdf_world/types.h>
+#else
+namespace urdf {
+typedef boost::shared_ptr<ModelInterface> ModelInterfaceSharedPtr;
+typedef boost::shared_ptr<const Link> LinkConstSharedPtr;
+typedef boost::shared_ptr<Joint> JointSharedPtr;
+}
+#endif
 
 using namespace urdf;
 using namespace std;

--- a/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/urdf_model_marker.h
+++ b/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/urdf_model_marker.h
@@ -36,6 +36,9 @@
 
 #include <jsk_topic_tools/time_accumulator.h>
 
+#include <urdf_model/types.h>
+#include <urdf_world/types.h>
+
 using namespace urdf;
 using namespace std;
 

--- a/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/urdf_model_marker.h
+++ b/jsk_interactive_markers/jsk_interactive_marker/include/jsk_interactive_marker/urdf_model_marker.h
@@ -47,8 +47,8 @@ class UrdfModelMarker {
   UrdfModelMarker(string model_name, string model_description, string model_file, string frame_id, geometry_msgs::PoseStamped  root_pose, geometry_msgs::Pose root_offset, double scale_factor, string mode, bool robot_mode, bool registration, vector<string> fixed_link, bool use_robot_description, bool use_visible_color, map<string, double> initial_pose_map, int index, std::shared_ptr<interactive_markers::InteractiveMarkerServer> server);
   UrdfModelMarker();
 
-  void addMoveMarkerControl(visualization_msgs::InteractiveMarker &int_marker, std::shared_ptr<const Link> link, bool root);
-  void addInvisibleMeshMarkerControl(visualization_msgs::InteractiveMarker &int_marker, std::shared_ptr<const Link> link, const std_msgs::ColorRGBA &color);
+  void addMoveMarkerControl(visualization_msgs::InteractiveMarker &int_marker, LinkConstSharedPtr link, bool root);
+  void addInvisibleMeshMarkerControl(visualization_msgs::InteractiveMarker &int_marker, LinkConstSharedPtr link, const std_msgs::ColorRGBA &color);
   void addGraspPointControl(visualization_msgs::InteractiveMarker &int_marker, std::string link_frame_name_);
 
   void publishBasePose( const visualization_msgs::InteractiveMarkerFeedbackConstPtr &feedback );
@@ -85,15 +85,15 @@ class UrdfModelMarker {
   //joint state methods
   void publishJointState();
   void getJointState();
-  void getJointState(std::shared_ptr<const Link> link);
+  void getJointState(LinkConstSharedPtr link);
 
-  void setJointState(std::shared_ptr<const Link> link, const sensor_msgs::JointStateConstPtr &js);
-  void setJointAngle(std::shared_ptr<const Link> link, double joint_angle);
+  void setJointState(LinkConstSharedPtr link, const sensor_msgs::JointStateConstPtr &js);
+  void setJointAngle(LinkConstSharedPtr link, double joint_angle);
   geometry_msgs::Pose getRootPose(geometry_msgs::Pose pose);
   geometry_msgs::PoseStamped getOriginPoseStamped();
-  void setOriginalPose(std::shared_ptr<const Link> link);
-  void addChildLinkNames(std::shared_ptr<const Link> link, bool root, bool init);
-  void addChildLinkNames(std::shared_ptr<const Link> link, bool root, bool init, bool use_color, int color_index);
+  void setOriginalPose(LinkConstSharedPtr link);
+  void addChildLinkNames(LinkConstSharedPtr link, bool root, bool init);
+  void addChildLinkNames(LinkConstSharedPtr link, bool root, bool init, bool use_color, int color_index);
 
   void callSetDynamicTf(string parent_frame_id, string frame_id, geometry_msgs::Transform transform);
   void callPublishTf();
@@ -170,7 +170,7 @@ class UrdfModelMarker {
   std::string target_frame;
 
 
-  std::shared_ptr<ModelInterface> model;
+  ModelInterfaceSharedPtr model;
   std::string model_name_;
   std::string model_description_;
   std::string frame_id_;

--- a/jsk_interactive_markers/jsk_interactive_marker/src/bounding_box_marker.cpp
+++ b/jsk_interactive_markers/jsk_interactive_marker/src/bounding_box_marker.cpp
@@ -40,7 +40,7 @@
 #include <boost/algorithm/string.hpp>
 
 
-boost::shared_ptr<interactive_markers::InteractiveMarkerServer> server;
+std::shared_ptr<interactive_markers::InteractiveMarkerServer> server;
 boost::mutex mutex;
 ros::Publisher pub, box_pub, box_arr_pub;
 jsk_recognition_msgs::BoundingBoxArray::ConstPtr box_msg;

--- a/jsk_interactive_markers/jsk_interactive_marker/src/camera_info_publisher.cpp
+++ b/jsk_interactive_markers/jsk_interactive_marker/src/camera_info_publisher.cpp
@@ -48,7 +48,7 @@ namespace jsk_interactive_marker
     pub_camera_info_ = pnh.advertise<sensor_msgs::CameraInfo>("camera_info", 1);
 
     // setup dynamic reconfigure
-    srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (pnh);
+    srv_ = std::make_shared <dynamic_reconfigure::Server<Config> > (pnh);
     dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (
         &CameraInfoPublisher::configCallback, this, _1, _2);

--- a/jsk_interactive_markers/jsk_interactive_marker/src/footstep_marker.cpp
+++ b/jsk_interactive_markers/jsk_interactive_marker/src/footstep_marker.cpp
@@ -61,7 +61,7 @@ plan_run_(false), lleg_first_(true) {
   tf_listener_.reset(new tf::TransformListener);
   ros::NodeHandle pnh("~");
   ros::NodeHandle nh;
-  srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (pnh);
+  srv_ = std::make_shared <dynamic_reconfigure::Server<Config> > (pnh);
   typename dynamic_reconfigure::Server<Config>::CallbackType f =
     boost::bind (&FootstepMarker::configCallback, this, _1, _2);
   srv_->setCallback (f);

--- a/jsk_interactive_markers/jsk_interactive_marker/src/interactive_marker_interface.cpp
+++ b/jsk_interactive_markers/jsk_interactive_marker/src/interactive_marker_interface.cpp
@@ -1134,7 +1134,7 @@ void InteractiveMarkerInterface::addHandMarker(visualization_msgs::InteractiveMa
         KDL::Frame origin_frame;
         tf::poseMsgToKDL(up.pose, origin_frame);
 
-        boost::shared_ptr<const Link> hand_root_link;
+        std::shared_ptr<const Link> hand_root_link;
         hand_root_link = up.model->getLink(up.root_link_name);
         if(!hand_root_link){
           hand_root_link = up.model->getRoot();

--- a/jsk_interactive_markers/jsk_interactive_marker/src/interactive_marker_interface.cpp
+++ b/jsk_interactive_markers/jsk_interactive_marker/src/interactive_marker_interface.cpp
@@ -1134,7 +1134,7 @@ void InteractiveMarkerInterface::addHandMarker(visualization_msgs::InteractiveMa
         KDL::Frame origin_frame;
         tf::poseMsgToKDL(up.pose, origin_frame);
 
-        std::shared_ptr<const Link> hand_root_link;
+        LinkConstSharedPtr hand_root_link;
         hand_root_link = up.model->getLink(up.root_link_name);
         if(!hand_root_link){
           hand_root_link = up.model->getRoot();

--- a/jsk_interactive_markers/jsk_interactive_marker/src/interactive_marker_utils.cpp
+++ b/jsk_interactive_markers/jsk_interactive_marker/src/interactive_marker_utils.cpp
@@ -143,11 +143,11 @@ namespace im_utils {
     return makeMeshMarkerControl(mesh_resource, stamped, scale, color, true);
   }
   
-  void addMeshLinksControl(visualization_msgs::InteractiveMarker &im, boost::shared_ptr<const Link> link, KDL::Frame previous_frame, bool use_color, std_msgs::ColorRGBA color, double scale){
+  void addMeshLinksControl(visualization_msgs::InteractiveMarker &im, std::shared_ptr<const Link> link, KDL::Frame previous_frame, bool use_color, std_msgs::ColorRGBA color, double scale){
     addMeshLinksControl(im, link, previous_frame, use_color, color, scale, true);
   }
 
-  void addMeshLinksControl(visualization_msgs::InteractiveMarker &im, boost::shared_ptr<const Link> link, KDL::Frame previous_frame, bool use_color, std_msgs::ColorRGBA color, double scale, bool root){
+  void addMeshLinksControl(visualization_msgs::InteractiveMarker &im, std::shared_ptr<const Link> link, KDL::Frame previous_frame, bool use_color, std_msgs::ColorRGBA color, double scale, bool root){
     if(!root && link->parent_joint){
       KDL::Frame parent_to_joint_frame;
       geometry_msgs::Pose parent_to_joint_pose = UrdfPose2Pose(link->parent_joint->parent_to_joint_origin_transform);
@@ -162,18 +162,18 @@ namespace im_utils {
 
     geometry_msgs::PoseStamped ps;
     //link_array
-    std::vector<boost::shared_ptr<Visual> > visual_array;
+    std::vector<std::shared_ptr<Visual> > visual_array;
     if(link->visual_array.size() != 0){
       visual_array = link->visual_array;
     }else if(link->visual.get() != NULL){
       visual_array.push_back(link->visual);
     }
     for(int i=0; i<visual_array.size(); i++){
-      boost::shared_ptr<Visual> link_visual = visual_array[i];
+      std::shared_ptr<Visual> link_visual = visual_array[i];
       if(link_visual.get() != NULL && link_visual->geometry.get() != NULL){
 	visualization_msgs::InteractiveMarkerControl meshControl;
 	if(link_visual->geometry->type == Geometry::MESH){
-	  boost::shared_ptr<const Mesh> mesh = boost::static_pointer_cast<const Mesh>(link_visual->geometry);
+	  std::shared_ptr<const Mesh> mesh = std::static_pointer_cast<const Mesh>(link_visual->geometry);
 	  string model_mesh_ = mesh->filename;
           model_mesh_ = getRosPathFromModelPath(model_mesh_);
           
@@ -198,7 +198,7 @@ namespace im_utils {
 	    meshControl = makeMeshMarkerControl(model_mesh_, ps, mesh_scale);
 	  }
 	}else if(link_visual->geometry->type == Geometry::CYLINDER){
-	  boost::shared_ptr<const Cylinder> cylinder = boost::static_pointer_cast<const Cylinder>(link_visual->geometry);
+	  std::shared_ptr<const Cylinder> cylinder = std::static_pointer_cast<const Cylinder>(link_visual->geometry);
 	  std::cout << "cylinder " << link->name;
 	  ps.pose = UrdfPose2Pose(link_visual->origin);
 	  double length = cylinder->length;
@@ -210,7 +210,7 @@ namespace im_utils {
 	    meshControl = makeCylinderMarkerControl(ps, length, radius, color, true);
 	  }
 	}else if(link_visual->geometry->type == Geometry::BOX){
-	  boost::shared_ptr<const Box> box = boost::static_pointer_cast<const Box>(link_visual->geometry);
+	  std::shared_ptr<const Box> box = std::static_pointer_cast<const Box>(link_visual->geometry);
 	  std::cout << "box " << link->name;
 	  ps.pose = UrdfPose2Pose(link_visual->origin);
 	  Vector3 dim = box->dim;
@@ -221,7 +221,7 @@ namespace im_utils {
 	    meshControl = makeBoxMarkerControl(ps, dim, color, true);
 	  }
 	}else if(link_visual->geometry->type == Geometry::SPHERE){
-	  boost::shared_ptr<const Sphere> sphere = boost::static_pointer_cast<const Sphere>(link_visual->geometry);
+	  std::shared_ptr<const Sphere> sphere = std::static_pointer_cast<const Sphere>(link_visual->geometry);
 	  ps.pose = UrdfPose2Pose(link_visual->origin);
 	  double rad = sphere->radius;
 	  if(use_color){
@@ -234,13 +234,13 @@ namespace im_utils {
 
       }
     }
-    for (std::vector<boost::shared_ptr<Link> >::const_iterator child = link->child_links.begin(); child != link->child_links.end(); child++){
+    for (std::vector<std::shared_ptr<Link> >::const_iterator child = link->child_links.begin(); child != link->child_links.end(); child++){
       addMeshLinksControl(im, *child, previous_frame, use_color, color, scale, false);
     }
   }
 
-  boost::shared_ptr<ModelInterface> getModelInterface(std::string model_file){
-    boost::shared_ptr<ModelInterface> model;
+  std::shared_ptr<ModelInterface> getModelInterface(std::string model_file){
+    std::shared_ptr<ModelInterface> model;
     model_file = getFilePathFromRosPath(model_file);
     model_file = getFullPathFromModelPath(model_file);
     std::string xml_string;
@@ -262,7 +262,7 @@ namespace im_utils {
   }
 
   //sample program
-  visualization_msgs::InteractiveMarker makeLinksMarker(boost::shared_ptr<const Link> link, bool use_color, std_msgs::ColorRGBA color, geometry_msgs::PoseStamped marker_ps, geometry_msgs::Pose origin_pose)
+  visualization_msgs::InteractiveMarker makeLinksMarker(std::shared_ptr<const Link> link, bool use_color, std_msgs::ColorRGBA color, geometry_msgs::PoseStamped marker_ps, geometry_msgs::Pose origin_pose)
   {
     visualization_msgs::InteractiveMarker int_marker;
     int_marker.header = marker_ps.header;

--- a/jsk_interactive_markers/jsk_interactive_marker/src/interactive_marker_utils.cpp
+++ b/jsk_interactive_markers/jsk_interactive_marker/src/interactive_marker_utils.cpp
@@ -143,11 +143,11 @@ namespace im_utils {
     return makeMeshMarkerControl(mesh_resource, stamped, scale, color, true);
   }
   
-  void addMeshLinksControl(visualization_msgs::InteractiveMarker &im, std::shared_ptr<const Link> link, KDL::Frame previous_frame, bool use_color, std_msgs::ColorRGBA color, double scale){
+  void addMeshLinksControl(visualization_msgs::InteractiveMarker &im, LinkConstSharedPtr link, KDL::Frame previous_frame, bool use_color, std_msgs::ColorRGBA color, double scale){
     addMeshLinksControl(im, link, previous_frame, use_color, color, scale, true);
   }
 
-  void addMeshLinksControl(visualization_msgs::InteractiveMarker &im, std::shared_ptr<const Link> link, KDL::Frame previous_frame, bool use_color, std_msgs::ColorRGBA color, double scale, bool root){
+  void addMeshLinksControl(visualization_msgs::InteractiveMarker &im, LinkConstSharedPtr link, KDL::Frame previous_frame, bool use_color, std_msgs::ColorRGBA color, double scale, bool root){
     if(!root && link->parent_joint){
       KDL::Frame parent_to_joint_frame;
       geometry_msgs::Pose parent_to_joint_pose = UrdfPose2Pose(link->parent_joint->parent_to_joint_origin_transform);
@@ -162,18 +162,22 @@ namespace im_utils {
 
     geometry_msgs::PoseStamped ps;
     //link_array
-    std::vector<std::shared_ptr<Visual> > visual_array;
+    std::vector<VisualSharedPtr> visual_array;
     if(link->visual_array.size() != 0){
       visual_array = link->visual_array;
     }else if(link->visual.get() != NULL){
       visual_array.push_back(link->visual);
     }
     for(int i=0; i<visual_array.size(); i++){
-      std::shared_ptr<Visual> link_visual = visual_array[i];
+      VisualSharedPtr link_visual = visual_array[i];
       if(link_visual.get() != NULL && link_visual->geometry.get() != NULL){
 	visualization_msgs::InteractiveMarkerControl meshControl;
 	if(link_visual->geometry->type == Geometry::MESH){
-	  std::shared_ptr<const Mesh> mesh = std::static_pointer_cast<const Mesh>(link_visual->geometry);
+#if ROS_VERSION_MINIMUM(1,14,0) // melodic
+	  MeshConstSharedPtr mesh = std::static_pointer_cast<const Mesh>(link_visual->geometry);
+#else
+        MeshConstSharedPtr mesh = boost::static_pointer_cast<const Mesh>(link_visual->geometry);
+#endif
 	  string model_mesh_ = mesh->filename;
           model_mesh_ = getRosPathFromModelPath(model_mesh_);
           
@@ -198,7 +202,11 @@ namespace im_utils {
 	    meshControl = makeMeshMarkerControl(model_mesh_, ps, mesh_scale);
 	  }
 	}else if(link_visual->geometry->type == Geometry::CYLINDER){
-	  std::shared_ptr<const Cylinder> cylinder = std::static_pointer_cast<const Cylinder>(link_visual->geometry);
+#if ROS_VERSION_MINIMUM(1,14,0) // melodic
+    CylinderConstSharedPtr cylinder = std::static_pointer_cast<const Cylinder>(link_visual->geometry);
+#else
+    CylinderConstSharedPtr cylinder = boost::static_pointer_cast<const Cylinder>(link_visual->geometry);
+#endif
 	  std::cout << "cylinder " << link->name;
 	  ps.pose = UrdfPose2Pose(link_visual->origin);
 	  double length = cylinder->length;
@@ -210,7 +218,11 @@ namespace im_utils {
 	    meshControl = makeCylinderMarkerControl(ps, length, radius, color, true);
 	  }
 	}else if(link_visual->geometry->type == Geometry::BOX){
-	  std::shared_ptr<const Box> box = std::static_pointer_cast<const Box>(link_visual->geometry);
+#if ROS_VERSION_MINIMUM(1,14,0) // melodic
+    BoxConstSharedPtr box = std::static_pointer_cast<const Box>(link_visual->geometry);
+#else
+    BoxConstSharedPtr box = boost::static_pointer_cast<const Box>(link_visual->geometry);
+#endif
 	  std::cout << "box " << link->name;
 	  ps.pose = UrdfPose2Pose(link_visual->origin);
 	  Vector3 dim = box->dim;
@@ -221,7 +233,11 @@ namespace im_utils {
 	    meshControl = makeBoxMarkerControl(ps, dim, color, true);
 	  }
 	}else if(link_visual->geometry->type == Geometry::SPHERE){
-	  std::shared_ptr<const Sphere> sphere = std::static_pointer_cast<const Sphere>(link_visual->geometry);
+#if ROS_VERSION_MINIMUM(1,14,0) // melodic
+    SphereConstSharedPtr sphere = std::static_pointer_cast<const Sphere>(link_visual->geometry);
+#else
+    SphereConstSharedPtr sphere = boost::static_pointer_cast<const Sphere>(link_visual->geometry);
+#endif
 	  ps.pose = UrdfPose2Pose(link_visual->origin);
 	  double rad = sphere->radius;
 	  if(use_color){
@@ -234,13 +250,13 @@ namespace im_utils {
 
       }
     }
-    for (std::vector<std::shared_ptr<Link> >::const_iterator child = link->child_links.begin(); child != link->child_links.end(); child++){
+    for (std::vector<LinkSharedPtr>::const_iterator child = link->child_links.begin(); child != link->child_links.end(); child++){
       addMeshLinksControl(im, *child, previous_frame, use_color, color, scale, false);
     }
   }
 
-  std::shared_ptr<ModelInterface> getModelInterface(std::string model_file){
-    std::shared_ptr<ModelInterface> model;
+  ModelInterfaceSharedPtr getModelInterface(std::string model_file){
+    ModelInterfaceSharedPtr model;
     model_file = getFilePathFromRosPath(model_file);
     model_file = getFullPathFromModelPath(model_file);
     std::string xml_string;
@@ -262,7 +278,7 @@ namespace im_utils {
   }
 
   //sample program
-  visualization_msgs::InteractiveMarker makeLinksMarker(std::shared_ptr<const Link> link, bool use_color, std_msgs::ColorRGBA color, geometry_msgs::PoseStamped marker_ps, geometry_msgs::Pose origin_pose)
+  visualization_msgs::InteractiveMarker makeLinksMarker(LinkConstSharedPtr link, bool use_color, std_msgs::ColorRGBA color, geometry_msgs::PoseStamped marker_ps, geometry_msgs::Pose origin_pose)
   {
     visualization_msgs::InteractiveMarker int_marker;
     int_marker.header = marker_ps.header;

--- a/jsk_interactive_markers/jsk_interactive_marker/src/interactive_point_cloud.cpp
+++ b/jsk_interactive_markers/jsk_interactive_marker/src/interactive_point_cloud.cpp
@@ -51,7 +51,7 @@ InteractivePointCloud::InteractivePointCloud(std::string marker_name,
 
   if(use_bounding_box_){
     //point cloud and bounding box
-    sync_ = boost::make_shared<message_filters::Synchronizer<SyncPolicy> >(10);
+    sync_ = std::make_shared<message_filters::Synchronizer<SyncPolicy> >(10);
     sub_bounding_box_.subscribe(pnh_,input_bounding_box_, 1);
     sub_initial_handle_pose_.subscribe(pnh_, initial_handle_pose_, 1);
     sync_->connectInput(sub_point_cloud_, sub_bounding_box_, sub_initial_handle_pose_);
@@ -60,7 +60,7 @@ InteractivePointCloud::InteractivePointCloud(std::string marker_name,
   }else{
       sub_point_cloud_.registerCallback(&InteractivePointCloud::pointCloudCallback, this);
   }
-  srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (pnh_);
+  srv_ = std::make_shared <dynamic_reconfigure::Server<Config> > (pnh_);
   dynamic_reconfigure::Server<Config>::CallbackType f =
     boost::bind (&InteractivePointCloud::configCallback, this, _1, _2);
   srv_->setCallback (f);

--- a/jsk_interactive_markers/jsk_interactive_marker/src/marker_6dof.cpp
+++ b/jsk_interactive_markers/jsk_interactive_marker/src/marker_6dof.cpp
@@ -316,7 +316,7 @@ protected:
     publishTF(pose);
   }
 
-  boost::shared_ptr<interactive_markers::InteractiveMarkerServer> server_;
+  std::shared_ptr<interactive_markers::InteractiveMarkerServer> server_;
   interactive_markers::MenuHandler menu_handler_;
   ros::Subscriber pose_stamped_sub_;
   ros::Publisher pose_pub_;
@@ -337,7 +337,7 @@ protected:
   std::string tf_frame_;
   ros::Timer timer_pose_;
   ros::Timer timer_tf_;
-  boost::shared_ptr<tf::TransformBroadcaster> tf_broadcaster_;
+  std::shared_ptr<tf::TransformBroadcaster> tf_broadcaster_;
   boost::mutex mutex_;
   interactive_markers::MenuHandler::EntryHandle circle_menu_entry_;
   geometry_msgs::PoseStamped latest_pose_;

--- a/jsk_interactive_markers/jsk_interactive_marker/src/parent_and_child_interactive_marker_server.cpp
+++ b/jsk_interactive_markers/jsk_interactive_marker/src/parent_and_child_interactive_marker_server.cpp
@@ -250,7 +250,7 @@ namespace jsk_interactive_marker
   bool ParentAndChildInteractiveMarkerServer::setCallback(const std::string &name, FeedbackCallback feedback_cb, uint8_t feedback_type)
   {
     // synthesize cbs
-    callback_map_[name] = boost::make_shared<FeedbackSynthesizer> (boost::bind(&ParentAndChildInteractiveMarkerServer::selfFeedbackCb, this, _1), feedback_cb);
+    callback_map_[name] = std::make_shared<FeedbackSynthesizer> (boost::bind(&ParentAndChildInteractiveMarkerServer::selfFeedbackCb, this, _1), feedback_cb);
     return interactive_markers::InteractiveMarkerServer::setCallback(name, boost::bind(&FeedbackSynthesizer::call_func, *callback_map_[name], _1), feedback_type);
   }
   void ParentAndChildInteractiveMarkerServer::insert(const visualization_msgs::InteractiveMarker &int_marker)

--- a/jsk_interactive_markers/jsk_interactive_marker/src/pointcloud_cropper.cpp
+++ b/jsk_interactive_markers/jsk_interactive_marker/src/pointcloud_cropper.cpp
@@ -73,7 +73,7 @@ namespace jsk_interactive_marker {
     output->points.clear();
     for (size_t i = 0; i < input->points.size(); i++) {
       pcl::PointXYZ p = input->points[i];
-      if (!isnan(p.x) && !isnan(p.y) && !isnan(p.z)) {
+      if (!std::isnan(p.x) && !std::isnan(p.y) && !std::isnan(p.z)) {
         if (isInside(p)) {
           output->points.push_back(p);
         }

--- a/jsk_interactive_markers/jsk_interactive_marker/src/pointcloud_cropper.cpp
+++ b/jsk_interactive_markers/jsk_interactive_marker/src/pointcloud_cropper.cpp
@@ -214,8 +214,8 @@ namespace jsk_interactive_marker {
   {
     tf_listener_.reset(new tf::TransformListener);
     // initialize cropper_candidates_
-    cropper_candidates_.push_back(boost::make_shared<SphereCropper>());
-    cropper_candidates_.push_back(boost::make_shared<CubeCropper>());
+    cropper_candidates_.push_back(std::make_shared<SphereCropper>());
+    cropper_candidates_.push_back(std::make_shared<CubeCropper>());
     cropper_ = cropper_candidates_[0];
     point_pub_ = pnh.advertise<sensor_msgs::PointCloud2>("output", 1);
     point_visualization_pub_ = pnh.advertise<sensor_msgs::PointCloud2>(
@@ -223,7 +223,7 @@ namespace jsk_interactive_marker {
     server_.reset(new interactive_markers::InteractiveMarkerServer(
                     ros::this_node::getName()));
     initializeInteractiveMarker();
-    srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (pnh);
+    srv_ = std::make_shared <dynamic_reconfigure::Server<Config> > (pnh);
     dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (&PointCloudCropper::configCallback, this, _1, _2);
     srv_->setCallback (f);

--- a/jsk_interactive_markers/jsk_interactive_marker/src/polygon_marker.cpp
+++ b/jsk_interactive_markers/jsk_interactive_marker/src/polygon_marker.cpp
@@ -41,7 +41,7 @@
 #include <jsk_recognition_utils/geo/polygon.h>
 #include <jsk_topic_tools/log_utils.h>
 
-boost::shared_ptr<interactive_markers::InteractiveMarkerServer> server;
+std::shared_ptr<interactive_markers::InteractiveMarkerServer> server;
 boost::mutex mutex;
 ros::Publisher pub, polygon_pub, polygon_arr_pub;
 jsk_recognition_msgs::PolygonArray::ConstPtr polygon_msg;

--- a/jsk_interactive_markers/jsk_interactive_marker/src/transformable_interactive_server.cpp
+++ b/jsk_interactive_markers/jsk_interactive_marker/src/transformable_interactive_server.cpp
@@ -49,7 +49,7 @@ TransformableInteractiveServer::TransformableInteractiveServer():n_(new ros::Nod
   marker_dimensions_pub_ = n_->advertise<jsk_interactive_marker::MarkerDimensions>("marker_dimensions", 1);
   request_marker_operate_srv_ = n_->advertiseService("request_marker_operate", &TransformableInteractiveServer::requestMarkerOperateService, this);
 
-  config_srv_ = boost::make_shared <dynamic_reconfigure::Server<InteractiveSettingConfig> > (*n_);
+  config_srv_ = std::make_shared <dynamic_reconfigure::Server<InteractiveSettingConfig> > (*n_);
   dynamic_reconfigure::Server<InteractiveSettingConfig>::CallbackType f =
     boost::bind (&TransformableInteractiveServer::configCallback, this, _1, _2);
   config_srv_->setCallback (f);
@@ -59,7 +59,7 @@ TransformableInteractiveServer::TransformableInteractiveServer():n_(new ros::Nod
   // initialize yaml-menu-handler
   std::string yaml_filename;
   n_->param("yaml_filename", yaml_filename, std::string(""));
-  yaml_menu_handler_ptr_ = boost::make_shared <YamlMenuHandler> (n_, yaml_filename);
+  yaml_menu_handler_ptr_ = std::make_shared <YamlMenuHandler> (n_, yaml_filename);
   yaml_menu_handler_ptr_->_menu_handler.insert(
     "enable manipulator",
     boost::bind(&TransformableInteractiveServer::enableInteractiveManipulatorDisplay, this, _1, /*enable=*/true));

--- a/jsk_interactive_markers/jsk_interactive_marker/src/urdf_control_marker.cpp
+++ b/jsk_interactive_markers/jsk_interactive_marker/src/urdf_control_marker.cpp
@@ -32,7 +32,7 @@ private:
   tf::TransformListener tf_listener_;
   ros::ServiceClient dynamic_tf_publisher_client_;
   ros::Subscriber sub_set_pose_, sub_show_marker_;
-  boost::shared_ptr<interactive_markers::InteractiveMarkerServer> server_;
+  std::shared_ptr<interactive_markers::InteractiveMarkerServer> server_;
   ros::NodeHandle nh_, pnh_;
   ros::Publisher pub_pose_, pub_selected_pose_;
   std::string frame_id_, marker_frame_id_, fixed_frame_id_;

--- a/jsk_interactive_markers/jsk_interactive_marker/src/urdf_model_marker.cpp
+++ b/jsk_interactive_markers/jsk_interactive_marker/src/urdf_model_marker.cpp
@@ -16,7 +16,7 @@ using namespace urdf;
 using namespace std;
 using namespace im_utils;
 
-void UrdfModelMarker::addMoveMarkerControl(visualization_msgs::InteractiveMarker &int_marker, boost::shared_ptr<const Link> link, bool root) {
+void UrdfModelMarker::addMoveMarkerControl(visualization_msgs::InteractiveMarker &int_marker, std::shared_ptr<const Link> link, bool root) {
   visualization_msgs::InteractiveMarkerControl control;
   if (root) {
     im_helpers::add6DofControl(int_marker,false);
@@ -25,7 +25,7 @@ void UrdfModelMarker::addMoveMarkerControl(visualization_msgs::InteractiveMarker
     }
   }
   else {
-    boost::shared_ptr<Joint> parent_joint = link->parent_joint;
+    std::shared_ptr<Joint> parent_joint = link->parent_joint;
     Eigen::Vector3f origin_x(1,0,0);
     Eigen::Vector3f dest_x(parent_joint->axis.x, parent_joint->axis.y, parent_joint->axis.z);
     Eigen::Quaternionf qua;
@@ -54,7 +54,7 @@ void UrdfModelMarker::addMoveMarkerControl(visualization_msgs::InteractiveMarker
   }
 }
 
-void UrdfModelMarker::addInvisibleMeshMarkerControl(visualization_msgs::InteractiveMarker &int_marker, boost::shared_ptr<const Link> link, const std_msgs::ColorRGBA &color) {
+void UrdfModelMarker::addInvisibleMeshMarkerControl(visualization_msgs::InteractiveMarker &int_marker, std::shared_ptr<const Link> link, const std_msgs::ColorRGBA &color) {
   visualization_msgs::InteractiveMarkerControl control;
   //    ps.pose = UrdfPose2Pose(link->visual->origin);
   visualization_msgs::Marker marker;
@@ -68,7 +68,7 @@ void UrdfModelMarker::addInvisibleMeshMarkerControl(visualization_msgs::Interact
   marker.color = color;
   //marker.pose = stamped.pose;
   //visualization_msgs::InteractiveMarkerControl control;
-  boost::shared_ptr<Joint> parent_joint = link->parent_joint;
+  std::shared_ptr<Joint> parent_joint = link->parent_joint;
   Eigen::Vector3f origin_x(0,0,1);
   Eigen::Vector3f dest_x(parent_joint->axis.x, parent_joint->axis.y, parent_joint->axis.z);
   Eigen::Quaternionf qua;
@@ -644,10 +644,10 @@ void UrdfModelMarker::getJointState() {
   getJointState(model->getRoot());
 }
 
-void UrdfModelMarker::getJointState(boost::shared_ptr<const Link> link)
+void UrdfModelMarker::getJointState(std::shared_ptr<const Link> link)
 {
   string link_frame_name_ =  tf_prefix_ + link->name;
-  boost::shared_ptr<Joint> parent_joint = link->parent_joint;
+  std::shared_ptr<Joint> parent_joint = link->parent_joint;
   if (parent_joint != NULL) {
     KDL::Frame initialFrame;
     KDL::Frame presentFrame;
@@ -745,15 +745,15 @@ void UrdfModelMarker::getJointState(boost::shared_ptr<const Link> link)
     server_->applyChanges();
   }
 
-  for (std::vector<boost::shared_ptr<Link> >::const_iterator child = link->child_links.begin(); child != link->child_links.end(); child++) {
+  for (std::vector<std::shared_ptr<Link> >::const_iterator child = link->child_links.begin(); child != link->child_links.end(); child++) {
     getJointState(*child);
   }
   return;
 }
 
-void UrdfModelMarker::setJointAngle(boost::shared_ptr<const Link> link, double joint_angle) {
+void UrdfModelMarker::setJointAngle(std::shared_ptr<const Link> link, double joint_angle) {
   string link_frame_name_ =  tf_prefix_ + link->name;
-  boost::shared_ptr<Joint> parent_joint = link->parent_joint;
+  std::shared_ptr<Joint> parent_joint = link->parent_joint;
 
   if (parent_joint == NULL) {
     return;
@@ -823,10 +823,10 @@ void UrdfModelMarker::setJointAngle(boost::shared_ptr<const Link> link, double j
   callSetDynamicTf(linkMarkerMap[link_frame_name_].frame_id, link_frame_name_, Pose2Transform(linkMarkerMap[link_frame_name_].pose));
 }
 
-void UrdfModelMarker::setJointState(boost::shared_ptr<const Link> link, const sensor_msgs::JointStateConstPtr &js)
+void UrdfModelMarker::setJointState(std::shared_ptr<const Link> link, const sensor_msgs::JointStateConstPtr &js)
 {
   string link_frame_name_ =  tf_prefix_ + link->name;
-  boost::shared_ptr<Joint> parent_joint = link->parent_joint;
+  std::shared_ptr<Joint> parent_joint = link->parent_joint;
   if (parent_joint != NULL) {
     KDL::Frame initialFrame;
     KDL::Frame presentFrame;
@@ -868,7 +868,7 @@ void UrdfModelMarker::setJointState(boost::shared_ptr<const Link> link, const se
       break;
     }
   }
-  for (std::vector<boost::shared_ptr<Link> >::const_iterator child = link->child_links.begin(); child != link->child_links.end(); child++) {
+  for (std::vector<std::shared_ptr<Link> >::const_iterator child = link->child_links.begin(); child != link->child_links.end(); child++) {
     setJointState(*child, js);
   }
   return;
@@ -899,22 +899,22 @@ geometry_msgs::PoseStamped UrdfModelMarker::getOriginPoseStamped() {
 }
 
 
-void UrdfModelMarker::setOriginalPose(boost::shared_ptr<const Link> link)
+void UrdfModelMarker::setOriginalPose(std::shared_ptr<const Link> link)
 {
   string link_frame_name_ =  tf_prefix_ + link->name;
   linkMarkerMap[link_frame_name_].origin =  linkMarkerMap[link_frame_name_].pose;
   
-  for (std::vector<boost::shared_ptr<Link> >::const_iterator child = link->child_links.begin(); child != link->child_links.end(); child++) {
+  for (std::vector<std::shared_ptr<Link> >::const_iterator child = link->child_links.begin(); child != link->child_links.end(); child++) {
     setOriginalPose(*child);
   }
 }
 
-void UrdfModelMarker::addChildLinkNames(boost::shared_ptr<const Link> link, bool root, bool init) {
+void UrdfModelMarker::addChildLinkNames(std::shared_ptr<const Link> link, bool root, bool init) {
   //addChildLinkNames(link, root, init, false, 0);
   addChildLinkNames(link, root, init, use_visible_color_, 0);
 }
 
-void UrdfModelMarker::addChildLinkNames(boost::shared_ptr<const Link> link, bool root, bool init, bool use_color, int color_index)
+void UrdfModelMarker::addChildLinkNames(std::shared_ptr<const Link> link, bool root, bool init, bool use_color, int color_index)
 {
   geometry_msgs::PoseStamped ps;
 
@@ -1019,7 +1019,7 @@ void UrdfModelMarker::addChildLinkNames(boost::shared_ptr<const Link> link, bool
     }
 
     //link_array
-    std::vector<boost::shared_ptr<Visual> > visual_array;
+    std::vector<std::shared_ptr<Visual> > visual_array;
     if (link->visual_array.size() != 0) {
       visual_array = link->visual_array;
     }
@@ -1027,11 +1027,11 @@ void UrdfModelMarker::addChildLinkNames(boost::shared_ptr<const Link> link, bool
       visual_array.push_back(link->visual);
     }
     for(int i=0; i<visual_array.size(); i++) {
-      boost::shared_ptr<Visual> link_visual = visual_array[i];
+      std::shared_ptr<Visual> link_visual = visual_array[i];
       if (link_visual.get() != NULL && link_visual->geometry.get() != NULL) {
         visualization_msgs::InteractiveMarkerControl meshControl;
         if (link_visual->geometry->type == Geometry::MESH) {
-          boost::shared_ptr<const Mesh> mesh = boost::static_pointer_cast<const Mesh>(link_visual->geometry);
+          std::shared_ptr<const Mesh> mesh = std::static_pointer_cast<const Mesh>(link_visual->geometry);
           string model_mesh_ = mesh->filename;
           if (linkMarkerMap[link_frame_name_].mesh_file == "") {
             model_mesh_ = getRosPathFromModelPath(model_mesh_);
@@ -1055,7 +1055,7 @@ void UrdfModelMarker::addChildLinkNames(boost::shared_ptr<const Link> link, bool
           }
         }
         else if (link_visual->geometry->type == Geometry::CYLINDER) {
-          boost::shared_ptr<const Cylinder> cylinder = boost::static_pointer_cast<const Cylinder>(link_visual->geometry);
+          std::shared_ptr<const Cylinder> cylinder = std::static_pointer_cast<const Cylinder>(link_visual->geometry);
           ps.pose = UrdfPose2Pose(link_visual->origin);
           double length = cylinder->length;
           double radius = cylinder->radius;
@@ -1068,7 +1068,7 @@ void UrdfModelMarker::addChildLinkNames(boost::shared_ptr<const Link> link, bool
           }
         }
         else if (link_visual->geometry->type == Geometry::BOX) {
-          boost::shared_ptr<const Box> box = boost::static_pointer_cast<const Box>(link_visual->geometry);
+          std::shared_ptr<const Box> box = std::static_pointer_cast<const Box>(link_visual->geometry);
           ps.pose = UrdfPose2Pose(link_visual->origin);
           Vector3 dim = box->dim;
           ROS_INFO_STREAM("box " << link->name << ", dim =  " << dim.x << ", " << dim.y << ", " << dim.z);
@@ -1080,7 +1080,7 @@ void UrdfModelMarker::addChildLinkNames(boost::shared_ptr<const Link> link, bool
           }
         }
         else if (link_visual->geometry->type == Geometry::SPHERE) {
-          boost::shared_ptr<const Sphere> sphere = boost::static_pointer_cast<const Sphere>(link_visual->geometry);
+          std::shared_ptr<const Sphere> sphere = std::static_pointer_cast<const Sphere>(link_visual->geometry);
           ps.pose = UrdfPose2Pose(link_visual->origin);
           double rad = sphere->radius;
           if (use_color) {
@@ -1100,7 +1100,7 @@ void UrdfModelMarker::addChildLinkNames(boost::shared_ptr<const Link> link, bool
 
       }
       else {
-        boost::shared_ptr<Joint> parent_joint = link->parent_joint;
+        std::shared_ptr<Joint> parent_joint = link->parent_joint;
         if (parent_joint != NULL) {
           if (parent_joint->type==Joint::REVOLUTE || parent_joint->type==Joint::REVOLUTE) {
             addInvisibleMeshMarkerControl(int_marker, link, color);
@@ -1148,7 +1148,7 @@ void UrdfModelMarker::addChildLinkNames(boost::shared_ptr<const Link> link, bool
 
   //  cout << "Link:" << link->name << endl;
 
-  for (std::vector<boost::shared_ptr<Link> >::const_iterator child = link->child_links.begin(); child != link->child_links.end(); child++) {
+  for (std::vector<std::shared_ptr<Link> >::const_iterator child = link->child_links.begin(); child != link->child_links.end(); child++) {
     addChildLinkNames(*child, false, init, use_color, color_index + 1);
   }
   if (root) {
@@ -1161,7 +1161,7 @@ void UrdfModelMarker::addChildLinkNames(boost::shared_ptr<const Link> link, bool
 UrdfModelMarker::UrdfModelMarker ()
 {}
 
-UrdfModelMarker::UrdfModelMarker (string model_name, string model_description, string model_file, string frame_id, geometry_msgs::PoseStamped root_pose, geometry_msgs::Pose root_offset, double scale_factor, string mode, bool robot_mode, bool registration, vector<string> fixed_link, bool use_robot_description, bool use_visible_color, map<string, double> initial_pose_map, int index,  boost::shared_ptr<interactive_markers::InteractiveMarkerServer> server) : nh_(), pnh_("~"), tfl_(nh_),use_dynamic_tf_(true), is_joint_states_locked_(false) {
+UrdfModelMarker::UrdfModelMarker (string model_name, string model_description, string model_file, string frame_id, geometry_msgs::PoseStamped root_pose, geometry_msgs::Pose root_offset, double scale_factor, string mode, bool robot_mode, bool registration, vector<string> fixed_link, bool use_robot_description, bool use_visible_color, map<string, double> initial_pose_map, int index,  std::shared_ptr<interactive_markers::InteractiveMarkerServer> server) : nh_(), pnh_("~"), tfl_(nh_),use_dynamic_tf_(true), is_joint_states_locked_(false) {
   diagnostic_updater_.reset(new diagnostic_updater::Updater);
   diagnostic_updater_->setHardwareID(ros::this_node::getName());
   diagnostic_updater_->add("Modeling Stats", boost::bind(&UrdfModelMarker::updateDiagnostic, this, _1));

--- a/jsk_interactive_markers/jsk_interactive_marker/src/urdf_model_marker.cpp
+++ b/jsk_interactive_markers/jsk_interactive_marker/src/urdf_model_marker.cpp
@@ -16,7 +16,7 @@ using namespace urdf;
 using namespace std;
 using namespace im_utils;
 
-void UrdfModelMarker::addMoveMarkerControl(visualization_msgs::InteractiveMarker &int_marker, std::shared_ptr<const Link> link, bool root) {
+void UrdfModelMarker::addMoveMarkerControl(visualization_msgs::InteractiveMarker &int_marker, LinkConstSharedPtr link, bool root) {
   visualization_msgs::InteractiveMarkerControl control;
   if (root) {
     im_helpers::add6DofControl(int_marker,false);
@@ -25,7 +25,7 @@ void UrdfModelMarker::addMoveMarkerControl(visualization_msgs::InteractiveMarker
     }
   }
   else {
-    std::shared_ptr<Joint> parent_joint = link->parent_joint;
+    JointSharedPtr parent_joint = link->parent_joint;
     Eigen::Vector3f origin_x(1,0,0);
     Eigen::Vector3f dest_x(parent_joint->axis.x, parent_joint->axis.y, parent_joint->axis.z);
     Eigen::Quaternionf qua;
@@ -54,7 +54,7 @@ void UrdfModelMarker::addMoveMarkerControl(visualization_msgs::InteractiveMarker
   }
 }
 
-void UrdfModelMarker::addInvisibleMeshMarkerControl(visualization_msgs::InteractiveMarker &int_marker, std::shared_ptr<const Link> link, const std_msgs::ColorRGBA &color) {
+void UrdfModelMarker::addInvisibleMeshMarkerControl(visualization_msgs::InteractiveMarker &int_marker, LinkConstSharedPtr link, const std_msgs::ColorRGBA &color) {
   visualization_msgs::InteractiveMarkerControl control;
   //    ps.pose = UrdfPose2Pose(link->visual->origin);
   visualization_msgs::Marker marker;
@@ -68,7 +68,7 @@ void UrdfModelMarker::addInvisibleMeshMarkerControl(visualization_msgs::Interact
   marker.color = color;
   //marker.pose = stamped.pose;
   //visualization_msgs::InteractiveMarkerControl control;
-  std::shared_ptr<Joint> parent_joint = link->parent_joint;
+  JointSharedPtr parent_joint = link->parent_joint;
   Eigen::Vector3f origin_x(0,0,1);
   Eigen::Vector3f dest_x(parent_joint->axis.x, parent_joint->axis.y, parent_joint->axis.z);
   Eigen::Quaternionf qua;
@@ -644,10 +644,10 @@ void UrdfModelMarker::getJointState() {
   getJointState(model->getRoot());
 }
 
-void UrdfModelMarker::getJointState(std::shared_ptr<const Link> link)
+void UrdfModelMarker::getJointState(LinkConstSharedPtr link)
 {
   string link_frame_name_ =  tf_prefix_ + link->name;
-  std::shared_ptr<Joint> parent_joint = link->parent_joint;
+  JointSharedPtr parent_joint = link->parent_joint;
   if (parent_joint != NULL) {
     KDL::Frame initialFrame;
     KDL::Frame presentFrame;
@@ -745,15 +745,15 @@ void UrdfModelMarker::getJointState(std::shared_ptr<const Link> link)
     server_->applyChanges();
   }
 
-  for (std::vector<std::shared_ptr<Link> >::const_iterator child = link->child_links.begin(); child != link->child_links.end(); child++) {
+  for (std::vector<LinkSharedPtr >::const_iterator child = link->child_links.begin(); child != link->child_links.end(); child++) {
     getJointState(*child);
   }
   return;
 }
 
-void UrdfModelMarker::setJointAngle(std::shared_ptr<const Link> link, double joint_angle) {
+void UrdfModelMarker::setJointAngle(LinkConstSharedPtr link, double joint_angle) {
   string link_frame_name_ =  tf_prefix_ + link->name;
-  std::shared_ptr<Joint> parent_joint = link->parent_joint;
+  JointSharedPtr parent_joint = link->parent_joint;
 
   if (parent_joint == NULL) {
     return;
@@ -823,10 +823,10 @@ void UrdfModelMarker::setJointAngle(std::shared_ptr<const Link> link, double joi
   callSetDynamicTf(linkMarkerMap[link_frame_name_].frame_id, link_frame_name_, Pose2Transform(linkMarkerMap[link_frame_name_].pose));
 }
 
-void UrdfModelMarker::setJointState(std::shared_ptr<const Link> link, const sensor_msgs::JointStateConstPtr &js)
+void UrdfModelMarker::setJointState(LinkConstSharedPtr link, const sensor_msgs::JointStateConstPtr &js)
 {
   string link_frame_name_ =  tf_prefix_ + link->name;
-  std::shared_ptr<Joint> parent_joint = link->parent_joint;
+  JointSharedPtr parent_joint = link->parent_joint;
   if (parent_joint != NULL) {
     KDL::Frame initialFrame;
     KDL::Frame presentFrame;
@@ -868,7 +868,7 @@ void UrdfModelMarker::setJointState(std::shared_ptr<const Link> link, const sens
       break;
     }
   }
-  for (std::vector<std::shared_ptr<Link> >::const_iterator child = link->child_links.begin(); child != link->child_links.end(); child++) {
+  for (std::vector<LinkSharedPtr >::const_iterator child = link->child_links.begin(); child != link->child_links.end(); child++) {
     setJointState(*child, js);
   }
   return;
@@ -899,22 +899,22 @@ geometry_msgs::PoseStamped UrdfModelMarker::getOriginPoseStamped() {
 }
 
 
-void UrdfModelMarker::setOriginalPose(std::shared_ptr<const Link> link)
+void UrdfModelMarker::setOriginalPose(LinkConstSharedPtr link)
 {
   string link_frame_name_ =  tf_prefix_ + link->name;
   linkMarkerMap[link_frame_name_].origin =  linkMarkerMap[link_frame_name_].pose;
   
-  for (std::vector<std::shared_ptr<Link> >::const_iterator child = link->child_links.begin(); child != link->child_links.end(); child++) {
+  for (std::vector<LinkSharedPtr >::const_iterator child = link->child_links.begin(); child != link->child_links.end(); child++) {
     setOriginalPose(*child);
   }
 }
 
-void UrdfModelMarker::addChildLinkNames(std::shared_ptr<const Link> link, bool root, bool init) {
+void UrdfModelMarker::addChildLinkNames(LinkConstSharedPtr link, bool root, bool init) {
   //addChildLinkNames(link, root, init, false, 0);
   addChildLinkNames(link, root, init, use_visible_color_, 0);
 }
 
-void UrdfModelMarker::addChildLinkNames(std::shared_ptr<const Link> link, bool root, bool init, bool use_color, int color_index)
+void UrdfModelMarker::addChildLinkNames(LinkConstSharedPtr link, bool root, bool init, bool use_color, int color_index)
 {
   geometry_msgs::PoseStamped ps;
 
@@ -1019,7 +1019,7 @@ void UrdfModelMarker::addChildLinkNames(std::shared_ptr<const Link> link, bool r
     }
 
     //link_array
-    std::vector<std::shared_ptr<Visual> > visual_array;
+    std::vector<VisualSharedPtr > visual_array;
     if (link->visual_array.size() != 0) {
       visual_array = link->visual_array;
     }
@@ -1027,11 +1027,15 @@ void UrdfModelMarker::addChildLinkNames(std::shared_ptr<const Link> link, bool r
       visual_array.push_back(link->visual);
     }
     for(int i=0; i<visual_array.size(); i++) {
-      std::shared_ptr<Visual> link_visual = visual_array[i];
+      VisualSharedPtr link_visual = visual_array[i];
       if (link_visual.get() != NULL && link_visual->geometry.get() != NULL) {
         visualization_msgs::InteractiveMarkerControl meshControl;
         if (link_visual->geometry->type == Geometry::MESH) {
-          std::shared_ptr<const Mesh> mesh = std::static_pointer_cast<const Mesh>(link_visual->geometry);
+#if ROS_VERSION_MINIMUM(1,14,0) // melodic
+          MeshConstSharedPtr mesh = std::static_pointer_cast<const Mesh>(link_visual->geometry);
+#else
+          MeshConstSharedPtr mesh = boost::static_pointer_cast<const Mesh>(link_visual->geometry);
+#endif
           string model_mesh_ = mesh->filename;
           if (linkMarkerMap[link_frame_name_].mesh_file == "") {
             model_mesh_ = getRosPathFromModelPath(model_mesh_);
@@ -1055,7 +1059,11 @@ void UrdfModelMarker::addChildLinkNames(std::shared_ptr<const Link> link, bool r
           }
         }
         else if (link_visual->geometry->type == Geometry::CYLINDER) {
-          std::shared_ptr<const Cylinder> cylinder = std::static_pointer_cast<const Cylinder>(link_visual->geometry);
+#if ROS_VERSION_MINIMUM(1,14,0) // melodic
+          CylinderConstSharedPtr cylinder = std::static_pointer_cast<const Cylinder>(link_visual->geometry);
+#else
+          CylinderConstSharedPtr cylinder = boost::static_pointer_cast<const Cylinder>(link_visual->geometry);
+#endif
           ps.pose = UrdfPose2Pose(link_visual->origin);
           double length = cylinder->length;
           double radius = cylinder->radius;
@@ -1068,7 +1076,11 @@ void UrdfModelMarker::addChildLinkNames(std::shared_ptr<const Link> link, bool r
           }
         }
         else if (link_visual->geometry->type == Geometry::BOX) {
-          std::shared_ptr<const Box> box = std::static_pointer_cast<const Box>(link_visual->geometry);
+#if ROS_VERSION_MINIMUM(1,14,0) // melodic
+          BoxConstSharedPtr box = std::static_pointer_cast<const Box>(link_visual->geometry);
+#else
+          BoxConstSharedPtr box = boost::static_pointer_cast<const Box>(link_visual->geometry);
+#endif
           ps.pose = UrdfPose2Pose(link_visual->origin);
           Vector3 dim = box->dim;
           ROS_INFO_STREAM("box " << link->name << ", dim =  " << dim.x << ", " << dim.y << ", " << dim.z);
@@ -1080,7 +1092,11 @@ void UrdfModelMarker::addChildLinkNames(std::shared_ptr<const Link> link, bool r
           }
         }
         else if (link_visual->geometry->type == Geometry::SPHERE) {
-          std::shared_ptr<const Sphere> sphere = std::static_pointer_cast<const Sphere>(link_visual->geometry);
+#if ROS_VERSION_MINIMUM(1,14,0) // melodic
+          SphereConstSharedPtr sphere = std::static_pointer_cast<const Sphere>(link_visual->geometry);
+#else
+          SphereConstSharedPtr sphere = boost::static_pointer_cast<const Sphere>(link_visual->geometry);
+#endif
           ps.pose = UrdfPose2Pose(link_visual->origin);
           double rad = sphere->radius;
           if (use_color) {
@@ -1100,7 +1116,7 @@ void UrdfModelMarker::addChildLinkNames(std::shared_ptr<const Link> link, bool r
 
       }
       else {
-        std::shared_ptr<Joint> parent_joint = link->parent_joint;
+        JointSharedPtr parent_joint = link->parent_joint;
         if (parent_joint != NULL) {
           if (parent_joint->type==Joint::REVOLUTE || parent_joint->type==Joint::REVOLUTE) {
             addInvisibleMeshMarkerControl(int_marker, link, color);
@@ -1148,7 +1164,7 @@ void UrdfModelMarker::addChildLinkNames(std::shared_ptr<const Link> link, bool r
 
   //  cout << "Link:" << link->name << endl;
 
-  for (std::vector<std::shared_ptr<Link> >::const_iterator child = link->child_links.begin(); child != link->child_links.end(); child++) {
+  for (std::vector<LinkSharedPtr >::const_iterator child = link->child_links.begin(); child != link->child_links.end(); child++) {
     addChildLinkNames(*child, false, init, use_color, color_index + 1);
   }
   if (root) {

--- a/jsk_interactive_markers/jsk_interactive_marker/src/urdf_model_marker_main.cpp
+++ b/jsk_interactive_markers/jsk_interactive_marker/src/urdf_model_marker_main.cpp
@@ -17,7 +17,7 @@ private:
   ros::NodeHandle pnh_;
   ros::Subscriber display_marker_sub_;
   XmlRpc::XmlRpcValue model_config_;
-  boost::shared_ptr<interactive_markers::InteractiveMarkerServer> server_;
+  std::shared_ptr<interactive_markers::InteractiveMarkerServer> server_;
   string model_name_;
   string model_description_;
   double scale_factor_;
@@ -34,7 +34,7 @@ private:
   bool display_;
   map<string, double> initial_pose_map_;
 
-  typedef boost::shared_ptr<UrdfModelMarker> umm_ptr;
+  typedef std::shared_ptr<UrdfModelMarker> umm_ptr;
   typedef vector<umm_ptr> umm_vec;
   umm_vec umm_vec_;
 
@@ -199,7 +199,7 @@ public:
     new UrdfModelMarker(model_name_, model_description_, model_file_, frame_id_, pose_stamped_ ,root_offset_, scale_factor_, mode_ , robot_mode_, registration_,fixed_link_, use_robot_description_, use_visible_color_,initial_pose_map_, -1, server_);
   }
 
-  UrdfModelSettings(XmlRpc::XmlRpcValue model,   boost::shared_ptr<interactive_markers::InteractiveMarkerServer> server) : pnh_("~") {
+  UrdfModelSettings(XmlRpc::XmlRpcValue model,   std::shared_ptr<interactive_markers::InteractiveMarkerServer> server) : pnh_("~") {
     model_config_ = model;
     server_ = server;
     init();
@@ -225,7 +225,7 @@ int main(int argc, char** argv)
     server_name = ros::this_node::getName();
   }
 
-  boost::shared_ptr<interactive_markers::InteractiveMarkerServer> server;
+  std::shared_ptr<interactive_markers::InteractiveMarkerServer> server;
   server.reset( new interactive_markers::InteractiveMarkerServer(server_name, "", false) );
 
   XmlRpc::XmlRpcValue v;

--- a/jsk_rviz_plugins/CMakeLists.txt
+++ b/jsk_rviz_plugins/CMakeLists.txt
@@ -4,6 +4,7 @@
 # http://ros.org/doc/groovy/api/catkin/html/user_guide/supposed.html
 cmake_minimum_required(VERSION 2.8.3)
 project(jsk_rviz_plugins)
+add_compile_options(-std=c++11)
 # Load catkin and all dependencies required for this package
 # TODO: remove all from COMPONENTS that are not catkin packages.
 find_package(catkin REQUIRED COMPONENTS rviz jsk_hark_msgs jsk_footstep_msgs jsk_recognition_utils

--- a/jsk_rviz_plugins/src/ambient_sound_display_groovy.cpp
+++ b/jsk_rviz_plugins/src/ambient_sound_display_groovy.cpp
@@ -234,7 +234,7 @@ namespace jsk_rviz_plugins
 
         // We are keeping a circular buffer of visual pointers.  This gets
         // the next one, or creates and stores it if it was missing.
-        boost::shared_ptr<AmbientSoundVisual> visual;
+        std::shared_ptr<AmbientSoundVisual> visual;
         //AmbientSoundVisual* visual_ptr;
         if( visuals_.full())
         {

--- a/jsk_rviz_plugins/src/ambient_sound_display_groovy.h
+++ b/jsk_rviz_plugins/src/ambient_sound_display_groovy.h
@@ -109,7 +109,7 @@ private:
   // adjustable history length, so we need one visual per history
   // item.
   //boost::circular_buffer<AmbientSoundVisual*> visuals_;
-  boost::circular_buffer<boost::shared_ptr<AmbientSoundVisual> > visuals_;
+  boost::circular_buffer<std::shared_ptr<AmbientSoundVisual> > visuals_;
 
   // A node in the Ogre scene tree to be the parent of all our visuals.
   //Ogre::SceneNode* scene_node_;

--- a/jsk_rviz_plugins/src/bounding_box_display_common.h
+++ b/jsk_rviz_plugins/src/bounding_box_display_common.h
@@ -59,9 +59,9 @@ namespace jsk_rviz_plugins
 public:
     BoundingBoxDisplayCommon() {};
     ~BoundingBoxDisplayCommon() {};
-    typedef boost::shared_ptr<rviz::Shape> ShapePtr;
-    typedef boost::shared_ptr<rviz::BillboardLine> BillboardLinePtr;
-    typedef boost::shared_ptr<rviz::Arrow> ArrowPtr;
+    typedef std::shared_ptr<rviz::Shape> ShapePtr;
+    typedef std::shared_ptr<rviz::BillboardLine> BillboardLinePtr;
+    typedef std::shared_ptr<rviz::Arrow> ArrowPtr;
 
 protected:
     QColor color_;

--- a/jsk_rviz_plugins/src/camera_info_display.h
+++ b/jsk_rviz_plugins/src/camera_info_display.h
@@ -61,7 +61,7 @@ namespace jsk_rviz_plugins
   class TrianglePolygon
   {
   public:
-    typedef boost::shared_ptr<TrianglePolygon> Ptr;
+    typedef std::shared_ptr<TrianglePolygon> Ptr;
     TrianglePolygon(Ogre::SceneManager* manager,
                     Ogre::SceneNode* node,
                     const cv::Point3d& O,
@@ -84,8 +84,8 @@ namespace jsk_rviz_plugins
   {
     Q_OBJECT
   public:
-    typedef boost::shared_ptr<rviz::Shape> ShapePtr;
-    typedef boost::shared_ptr<rviz::BillboardLine> BillboardLinePtr;
+    typedef std::shared_ptr<rviz::Shape> ShapePtr;
+    typedef std::shared_ptr<rviz::BillboardLine> BillboardLinePtr;
     CameraInfoDisplay();
     virtual ~CameraInfoDisplay();
     

--- a/jsk_rviz_plugins/src/facing_visualizer.h
+++ b/jsk_rviz_plugins/src/facing_visualizer.h
@@ -57,7 +57,7 @@ namespace jsk_rviz_plugins
   class SquareObject
   {
   public:
-    typedef boost::shared_ptr<SquareObject> Ptr;
+    typedef std::shared_ptr<SquareObject> Ptr;
     SquareObject(Ogre::SceneManager* manager,
                  double outer_radius,
                  double inner_radius,
@@ -86,7 +86,7 @@ namespace jsk_rviz_plugins
   class TextureObject           // utility class for texture
   {
   public:
-    typedef boost::shared_ptr<TextureObject> Ptr;
+    typedef std::shared_ptr<TextureObject> Ptr;
     TextureObject(const int width, const int height, const std::string name);
     virtual ~TextureObject();
     virtual int getWidth() { return width_; };
@@ -106,7 +106,7 @@ namespace jsk_rviz_plugins
   class FacingObject
   {
   public:
-    typedef boost::shared_ptr<FacingObject> Ptr;
+    typedef std::shared_ptr<FacingObject> Ptr;
     FacingObject(Ogre::SceneManager* manager,
                  Ogre::SceneNode* parent,
                  double size);
@@ -137,7 +137,7 @@ namespace jsk_rviz_plugins
   class SimpleCircleFacingVisualizer: public FacingObject
   {
   public:
-    typedef boost::shared_ptr<SimpleCircleFacingVisualizer> Ptr;
+    typedef std::shared_ptr<SimpleCircleFacingVisualizer> Ptr;
     SimpleCircleFacingVisualizer(Ogre::SceneManager* manager,
                                  Ogre::SceneNode* parent,
                                  rviz::DisplayContext* context,
@@ -184,7 +184,7 @@ namespace jsk_rviz_plugins
   class FacingTexturedObject: public FacingObject
   {
   public:
-    typedef boost::shared_ptr<FacingTexturedObject> Ptr;
+    typedef std::shared_ptr<FacingTexturedObject> Ptr;
     FacingTexturedObject(Ogre::SceneManager* manager,
                          Ogre::SceneNode* parent,
                          double size);
@@ -200,7 +200,7 @@ namespace jsk_rviz_plugins
   class GISCircleVisualizer: public FacingTexturedObject
   {
   public:
-    typedef boost::shared_ptr<GISCircleVisualizer> Ptr;
+    typedef std::shared_ptr<GISCircleVisualizer> Ptr;
     GISCircleVisualizer(Ogre::SceneManager* manager,
                         Ogre::SceneNode* parent,
                         double size,

--- a/jsk_rviz_plugins/src/footstep_display.h
+++ b/jsk_rviz_plugins/src/footstep_display.h
@@ -75,7 +75,7 @@ namespace jsk_rviz_plugins
     rviz::BoolProperty* show_name_property_;
     rviz::BoolProperty* use_group_coloring_property_;
     jsk_footstep_msgs::FootstepArray::ConstPtr latest_footstep_;
-    typedef boost::shared_ptr<rviz::Shape> ShapePtr;
+    typedef std::shared_ptr<rviz::Shape> ShapePtr;
     std::vector<ShapePtr> shapes_;
     std::vector<rviz::MovableText*> texts_;
     std::vector<Ogre::SceneNode*> text_nodes_;

--- a/jsk_rviz_plugins/src/normal_display.cpp
+++ b/jsk_rviz_plugins/src/normal_display.cpp
@@ -232,7 +232,7 @@ namespace jsk_rviz_plugins
 
         if (validateFloats(Ogre::Vector3(x, y, z)) && validateFloats(Ogre::Vector3(normal_x, normal_y, normal_z)))
           {
-            boost::shared_ptr<NormalVisual> visual;
+            std::shared_ptr<NormalVisual> visual;
             if(visuals_.full()){
               visual = visuals_.front();
             }else{

--- a/jsk_rviz_plugins/src/normal_display.h
+++ b/jsk_rviz_plugins/src/normal_display.h
@@ -56,7 +56,7 @@ protected:
 
   virtual void reset();
 
-  boost::circular_buffer<boost::shared_ptr<NormalVisual> > visuals_;
+  boost::circular_buffer<std::shared_ptr<NormalVisual> > visuals_;
 
   // Function to handle an incoming ROS message.
 private Q_SLOTS:

--- a/jsk_rviz_plugins/src/normal_visual.h
+++ b/jsk_rviz_plugins/src/normal_visual.h
@@ -27,7 +27,7 @@ namespace jsk_rviz_plugins
     void setScale( float scale );
 
   private:
-    boost::shared_ptr<rviz::Arrow> normal_arrow_;
+    std::shared_ptr<rviz::Arrow> normal_arrow_;
     Ogre::SceneNode* frame_node_;
     Ogre::SceneManager* scene_manager_;
   };

--- a/jsk_rviz_plugins/src/overlay_diagnostic_display.cpp
+++ b/jsk_rviz_plugins/src/overlay_diagnostic_display.cpp
@@ -113,7 +113,7 @@ namespace jsk_rviz_plugins
     const diagnostic_msgs::DiagnosticArray::ConstPtr& msg)
   {
     boost::mutex::scoped_lock(mutex_);
-    //boost::make_shared<diagnostic_msgs::DiagnosticStatus>
+    //std::make_shared<diagnostic_msgs::DiagnosticStatus>
     // update namespaces_ if needed
     std::set<std::string> new_namespaces;
     for (size_t i = 0; i < msg->status.size(); i++) {
@@ -149,7 +149,7 @@ namespace jsk_rviz_plugins
       diagnostic_msgs::DiagnosticStatus status = msg->status[i];
       if (status.name == diagnostics_namespace_) {
         latest_status_
-          = boost::make_shared<diagnostic_msgs::DiagnosticStatus>(status);
+          = std::make_shared<diagnostic_msgs::DiagnosticStatus>(status);
         latest_message_time_ = ros::WallTime::now();
         break;
       }

--- a/jsk_rviz_plugins/src/overlay_diagnostic_display.h
+++ b/jsk_rviz_plugins/src/overlay_diagnostic_display.h
@@ -115,7 +115,7 @@ namespace jsk_rviz_plugins
     boost::mutex mutex_;
     OverlayObject::Ptr overlay_;
     
-    diagnostic_msgs::DiagnosticStatus::Ptr latest_status_;
+    std::shared_ptr<diagnostic_msgs::DiagnosticStatus> latest_status_;
     State previous_state_;
     ros::WallTime latest_message_time_;
     ros::WallTime animation_start_time_;

--- a/jsk_rviz_plugins/src/overlay_image_display.cpp
+++ b/jsk_rviz_plugins/src/overlay_image_display.cpp
@@ -92,7 +92,7 @@ namespace jsk_rviz_plugins
   void OverlayImageDisplay::onInitialize()
   {
     ros::NodeHandle nh;
-    it_ = boost::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(nh));
+    it_ = std::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(nh));
     
     updateWidth();
     updateHeight();

--- a/jsk_rviz_plugins/src/overlay_image_display.h
+++ b/jsk_rviz_plugins/src/overlay_image_display.h
@@ -82,7 +82,7 @@ namespace jsk_rviz_plugins
     rviz::FloatProperty* alpha_property_;
     int width_, height_, left_, top_;
     double alpha_;
-    boost::shared_ptr<image_transport::ImageTransport> it_;
+    std::shared_ptr<image_transport::ImageTransport> it_;
     image_transport::Subscriber sub_;
     sensor_msgs::Image::ConstPtr msg_;
     bool is_msg_available_;

--- a/jsk_rviz_plugins/src/overlay_utils.h
+++ b/jsk_rviz_plugins/src/overlay_utils.h
@@ -86,7 +86,7 @@ namespace jsk_rviz_plugins
   class OverlayObject
   {
   public:
-    typedef boost::shared_ptr<OverlayObject> Ptr;
+    typedef std::shared_ptr<OverlayObject> Ptr;
     
     OverlayObject(const std::string& name);
     virtual ~OverlayObject();

--- a/jsk_rviz_plugins/src/pictogram_display.h
+++ b/jsk_rviz_plugins/src/pictogram_display.h
@@ -68,7 +68,7 @@ namespace jsk_rviz_plugins
   class PictogramObject: public FacingTexturedObject
   {
   public:
-    typedef boost::shared_ptr<PictogramObject> Ptr;
+    typedef std::shared_ptr<PictogramObject> Ptr;
     PictogramObject(Ogre::SceneManager* manager,
                     Ogre::SceneNode* parent,
                     double size);

--- a/jsk_rviz_plugins/src/polygon_array_display.h
+++ b/jsk_rviz_plugins/src/polygon_array_display.h
@@ -61,7 +61,7 @@ namespace jsk_rviz_plugins
   {
     Q_OBJECT
   public:
-    typedef boost::shared_ptr<rviz::Arrow> ArrowPtr;
+    typedef std::shared_ptr<rviz::Arrow> ArrowPtr;
     PolygonArrayDisplay();
     virtual ~PolygonArrayDisplay();
   protected:

--- a/jsk_rviz_plugins/src/segment_array_display.h
+++ b/jsk_rviz_plugins/src/segment_array_display.h
@@ -56,7 +56,7 @@ namespace jsk_rviz_plugins
   {
     Q_OBJECT
   public:
-    typedef boost::shared_ptr<rviz::BillboardLine> BillboardLinePtr;
+    typedef std::shared_ptr<rviz::BillboardLine> BillboardLinePtr;
     SegmentArrayDisplay();
     virtual ~SegmentArrayDisplay();
   protected:

--- a/jsk_rviz_plugins/src/simple_occupancy_grid_array_display.h
+++ b/jsk_rviz_plugins/src/simple_occupancy_grid_array_display.h
@@ -54,7 +54,7 @@ namespace jsk_rviz_plugins
   {
     Q_OBJECT
   public:
-    typedef boost::shared_ptr<rviz::PointCloud> PointCloudPtr;
+    typedef std::shared_ptr<rviz::PointCloud> PointCloudPtr;
     SimpleOccupancyGridArrayDisplay();
     virtual ~SimpleOccupancyGridArrayDisplay();
   protected:

--- a/jsk_rviz_plugins/src/torus_array_display.h
+++ b/jsk_rviz_plugins/src/torus_array_display.h
@@ -60,8 +60,8 @@ namespace jsk_rviz_plugins
   {
     Q_OBJECT
   public:
-    typedef boost::shared_ptr<rviz::Arrow> ArrowPtr;
-    typedef boost::shared_ptr<rviz::MeshShape> ShapePtr;
+    typedef std::shared_ptr<rviz::Arrow> ArrowPtr;
+    typedef std::shared_ptr<rviz::MeshShape> ShapePtr;
     TorusArrayDisplay();
     virtual ~TorusArrayDisplay();
   protected:

--- a/jsk_rviz_plugins/src/twist_stamped_display.h
+++ b/jsk_rviz_plugins/src/twist_stamped_display.h
@@ -60,8 +60,8 @@ namespace jsk_rviz_plugins
   {
     Q_OBJECT
   public:
-    typedef boost::shared_ptr<rviz::Arrow> ArrowPtr;
-    typedef boost::shared_ptr<rviz::BillboardLine> BillboardLinePtr;
+    typedef std::shared_ptr<rviz::Arrow> ArrowPtr;
+    typedef std::shared_ptr<rviz::BillboardLine> BillboardLinePtr;
     TwistStampedDisplay();
     virtual ~TwistStampedDisplay();
   protected:

--- a/jsk_rviz_plugins/src/video_capture_display.h
+++ b/jsk_rviz_plugins/src/video_capture_display.h
@@ -49,7 +49,7 @@ namespace jsk_rviz_plugins
   {
     Q_OBJECT
   public:
-    typedef boost::shared_ptr<VideoCaptureDisplay> Ptr;
+    typedef std::shared_ptr<VideoCaptureDisplay> Ptr;
     VideoCaptureDisplay();
     virtual ~VideoCaptureDisplay();
   protected:


### PR DESCRIPTION
This PR replaces `boost::shared_ptr` by `std::shared_ptr` and related methods, to build on ROS melodic.

These changes will break the kinetic build. Can you create a `melodic-devel` branch where I can rebase this on?
Also, the melodic CI job is missing `jsk_recognition_utils`.