### PR TITLE
[jsk_rviz_plugins/CameraInfo] Avoid Crash when specified invalid camera info and add warning.

### DIFF
--- a/jsk_rviz_plugins/src/camera_info_display.cpp
+++ b/jsk_rviz_plugins/src/camera_info_display.cpp
@@ -250,7 +250,18 @@ namespace jsk_rviz_plugins
       return false;
     }
   }
-  
+
+  bool CameraInfoDisplay::isValidCameraInfo(
+    const sensor_msgs::CameraInfo::ConstPtr& msg) {
+    // check fx and fy are not zero.
+    if (msg->P[0] == 0.0 &&
+        msg->P[5] == 0.0) {
+      return false;
+    } else {
+      return true;
+    }
+  }
+
   void CameraInfoDisplay::addPointToEdge(
     const cv::Point3d& point)
   {

--- a/jsk_rviz_plugins/src/camera_info_display.cpp
+++ b/jsk_rviz_plugins/src/camera_info_display.cpp
@@ -194,6 +194,10 @@ namespace jsk_rviz_plugins
   void CameraInfoDisplay::processMessage(
     const sensor_msgs::CameraInfo::ConstPtr& msg)
   {
+    if (!isValidCameraInfo(msg)) {
+      ROS_WARN("camera info is not valid. Please check the specified camera info has a valid projection matrix");
+      return;
+    }
     if (!isSameCameraInfo(msg)) {
       createCameraInfoShapes(msg);
     }

--- a/jsk_rviz_plugins/src/camera_info_display.h
+++ b/jsk_rviz_plugins/src/camera_info_display.h
@@ -102,6 +102,8 @@ namespace jsk_rviz_plugins
     virtual void update(float wall_dt, float ros_dt);
     virtual bool isSameCameraInfo(
       const sensor_msgs::CameraInfo::ConstPtr& camera_info);
+    virtual bool isValidCameraInfo(
+      const sensor_msgs::CameraInfo::ConstPtr& camera_info);
     virtual void createCameraInfoShapes(
       const sensor_msgs::CameraInfo::ConstPtr& camera_info);
     virtual void addPointToEdge(


### PR DESCRIPTION
Related to https://github.com/jsk-ros-pkg/jsk_visualization/issues/713
Current ```jsk_rviz_plugins/CameraInfo``` crashes when specified invalid camera info (fx(P[0]) and fy(P[5]) are zeros).
With this patch, we can avoid that crashes.