### PR TITLE
Replace image_pipeline with image_publisher

### DIFF
--- a/jsk_rqt_plugins/package.xml
+++ b/jsk_rqt_plugins/package.xml
@@ -26,7 +26,7 @@
   <run_depend>qt_gui_py_common</run_depend>
   <run_depend>resource_retriever</run_depend>
   <!-- https://github.com/ros-perception/image_pipeline/pull/318 -->
-  <run_depend version_gte="1.12.23">image_pipeline</run_depend>
+  <run_depend version_gte="1.12.23">image_publisher</run_depend>
   <run_depend>image_view2</run_depend>
   <run_depend version_gte="4.3.0" >jsk_gui_msgs</run_depend>
   <run_depend>cv_bridge</run_depend>


### PR DESCRIPTION
* image_pipeline is a meta package and normal ros packages are not
  intended to depend on meta packages.
* `catkin build` reports it as warning as following:
<img width="789" alt="スクリーンショット 2019-04-13 14 25 42" src="https://user-images.githubusercontent.com/40454/56075259-8b319380-5dfa-11e9-9690-1a0ce20af673.png">
