### PR TITLE
Add transport hint field to OverlayImage display

### DIFF
--- a/jsk_rviz_plugins/src/overlay_image_display.h
+++ b/jsk_rviz_plugins/src/overlay_image_display.h
@@ -47,6 +47,7 @@
 #include <rviz/properties/int_property.h>
 #include <rviz/properties/float_property.h>
 #include <rviz/properties/bool_property.h>
+#include <rviz/properties/editable_enum_property.h>
 
 #include <image_transport/image_transport.h>
 #include <sensor_msgs/Image.h>
@@ -74,6 +75,7 @@ namespace jsk_rviz_plugins
     boost::mutex mutex_;
     OverlayObject::Ptr overlay_;
     rviz::RosTopicProperty* update_topic_property_;
+    rviz::EditableEnumProperty* transport_hint_property_;
     rviz::BoolProperty* keep_aspect_ratio_property_;
     rviz::IntProperty* width_property_;
     rviz::IntProperty* height_property_;


### PR DESCRIPTION
* Add an editable enum field to specify transport hint on
  OverlayImage display.
* raw, compressed and theora are listed as pre-defined transport
  hints.

<img width="173" alt="スクリーンショット 2019-04-13 15 19 21" src="https://user-images.githubusercontent.com/40454/56075594-cd110880-5dff-11e9-9d1e-3d4dadea7327.png">
