### PR TITLE
Fix format specifier

### DIFF
--- a/jsk_rviz_plugins/src/camera_info_display.cpp
+++ b/jsk_rviz_plugins/src/camera_info_display.cpp
@@ -366,8 +366,8 @@ namespace jsk_rviz_plugins
     if (use_image_ && !image_.empty() &&
         bottom_texture_->getHeight() == image_.rows &&
         bottom_texture_->getWidth() == image_.cols) {
-      ROS_DEBUG("bottom_texture_->getHeight(): %lu", bottom_texture_->getHeight());
-      ROS_DEBUG("bottom_texture_->getWidth(): %lu", bottom_texture_->getWidth());
+      ROS_DEBUG("bottom_texture_->getHeight(): %u", bottom_texture_->getHeight());
+      ROS_DEBUG("bottom_texture_->getWidth(): %u", bottom_texture_->getWidth());
       ROS_DEBUG("image_.rows: %d", image_.rows);
       ROS_DEBUG("image_.cols: %d", image_.cols);
 


### PR DESCRIPTION
* Use %u instead of %lu to print Ogre::Texture::getWidth() and
  Ogre::Texture::getHeight() because they return uint32.

https://www.ogre3d.org/docs/api/1.9/class_ogre_1_1_texture.html#a03b77fa04181bc3bd30323555b425667

The following warning will disappear after merging this PR.

```
/home/ryohei/gitai/catkin_ws/src/jsk_visualization/jsk_rviz_plugins/src/camera_info_display.cpp: In member function ‘virtual void jsk_rviz_plugins::CameraInfoDisplay::drawImageTexture()’:
/home/ryohei/gitai/catkin_ws/src/jsk_visualization/jsk_rviz_plugins/src/camera_info_display.cpp:369:1173: warning: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 8 has type ‘Ogre::uint32 {aka unsigned int}’ [-Wformat=]
/home/ryohei/gitai/catkin_ws/src/jsk_visualization/jsk_rviz_plugins/src/camera_info_display.cpp:370:1171: warning: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 8 has type ‘Ogre::uint32 {aka unsigned int}’ [-Wformat=]
```
