### PR TITLE
Do not subscribe image topic when rviz startups in OverlayImage display

### DIFF
--- a/jsk_rviz_plugins/src/overlay_image_display.cpp
+++ b/jsk_rviz_plugins/src/overlay_image_display.cpp
@@ -126,10 +126,12 @@ namespace jsk_rviz_plugins
 
   void OverlayImageDisplay::subscribe()
   {
-    std::string topic_name = update_topic_property_->getTopicStd();
-    
-    if (topic_name.length() > 0 && topic_name != "/") {
-      sub_ = it_->subscribe(topic_name, 1, &OverlayImageDisplay::processMessage, this);
+    if (isEnabled()) {
+      std::string topic_name = update_topic_property_->getTopicStd();
+
+      if (topic_name.length() > 0 && topic_name != "/") {
+        sub_ = it_->subscribe(topic_name, 1, &OverlayImageDisplay::processMessage, this);
+      }
     }
   }
 


### PR DESCRIPTION
* In order not to subscribe image topic when rviz startups with
  OverlayImage display disabled, always verify if the display is
  enabled before the display subscribes topic.