### PR TITLE
Add transport hint to CameraInfoDisplay

### DIFF
--- a/jsk_rviz_plugins/CMakeLists.txt
+++ b/jsk_rviz_plugins/CMakeLists.txt
@@ -110,6 +110,7 @@ set(HEADER_FILES
   src/tf_trajectory_display.h
   src/yes_no_button_interface.h
   src/segment_array_display.h
+  src/image_transport_hints_property.h
 )
 
 if(rviz_QT_VERSION VERSION_LESS "5")
@@ -164,6 +165,7 @@ set(SOURCE_FILES
   src/tf_trajectory_display.cpp
   src/yes_no_button_interface.cpp
   src/segment_array_display.cpp
+  src/image_transport_hints_property.cpp
   ${MOC_FILES}
 )
 

--- a/jsk_rviz_plugins/src/camera_info_display.cpp
+++ b/jsk_rviz_plugins/src/camera_info_display.cpp
@@ -34,6 +34,7 @@
  *********************************************************************/
 
 #include <rviz/uniform_string_stream.h>
+#include <image_transport/image_transport.h>
 #include "camera_info_display.h"
 #include <OGRE/OgreMaterialManager.h>
 #include <OGRE/OgreMaterial.h>
@@ -136,6 +137,12 @@ namespace jsk_rviz_plugins
       "sensor_msgs::Image topic to subscribe to.",
       this, SLOT( updateImageTopic() ));
     image_topic_property_->hide();
+    image_transport_hints_property_ = new ImageTransportHintsProperty(
+      "transport hints",
+      "transport hint for image subscription",
+      this, SLOT( updateImageTopic() ));
+    image_transport_hints_property_->hide();
+
     color_property_ = new rviz::ColorProperty(
       "color",
       QColor(85, 255, 255),
@@ -350,8 +357,9 @@ namespace jsk_rviz_plugins
       ROS_WARN("topic name is empty");
     }
     ros::NodeHandle nh;
-    image_sub_ = nh.subscribe(topic, 1, 
-                              &CameraInfoDisplay::imageCallback, this);
+    image_transport::ImageTransport it(nh);
+    image_sub_ = it.subscribe(topic, 1, &CameraInfoDisplay::imageCallback, this,
+                              image_transport_hints_property_->getTransportHints());
   }
   
   void CameraInfoDisplay::drawImageTexture()
@@ -589,10 +597,12 @@ namespace jsk_rviz_plugins
     use_image_ = use_image_property_->getBool();
     if (use_image_) {
       image_topic_property_->show();
+      image_transport_hints_property_->show();
       updateImageTopic();
     }
     else {
       image_topic_property_->hide();
+      image_transport_hints_property_->hide();
     }
   }
   void CameraInfoDisplay::updateNotShowSidePolygons()

--- a/jsk_rviz_plugins/src/camera_info_display.h
+++ b/jsk_rviz_plugins/src/camera_info_display.h
@@ -54,6 +54,9 @@
 #include <OGRE/OgreTexture.h>
 #include <cv_bridge/cv_bridge.h>
 #include <sensor_msgs/image_encodings.h>
+#include <image_transport/subscriber.h>
+
+#include "image_transport_hints_property.h"
 #endif
 
 namespace jsk_rviz_plugins
@@ -124,7 +127,7 @@ namespace jsk_rviz_plugins
     Ogre::TexturePtr texture_;
     Ogre::MaterialPtr material_bottom_;
     Ogre::TexturePtr bottom_texture_;
-    ros::Subscriber image_sub_;
+    image_transport::Subscriber image_sub_;
     boost::mutex mutex_;
     ////////////////////////////////////////////////////////
     // variables updated by rviz properties
@@ -142,6 +145,7 @@ namespace jsk_rviz_plugins
     ////////////////////////////////////////////////////////
     // properties
     ////////////////////////////////////////////////////////
+    ImageTransportHintsProperty* image_transport_hints_property_;
     rviz::FloatProperty* far_clip_distance_property_;
     rviz::FloatProperty* alpha_property_;
     rviz::ColorProperty* color_property_;

--- a/jsk_rviz_plugins/src/image_transport_hints_property.cpp
+++ b/jsk_rviz_plugins/src/image_transport_hints_property.cpp
@@ -1,0 +1,21 @@
+#include "image_transport_hints_property.h"
+
+namespace jsk_rviz_plugins {
+
+ImageTransportHintsProperty::ImageTransportHintsProperty(const char* name,
+                                                         const char* description,
+                                                         rviz::Property* parent,
+                                                         const char* changed_slot)
+    : rviz::EditableEnumProperty(name, "raw", description, parent, changed_slot) {
+  addOptionStd("raw");
+  addOptionStd("compressed");
+  addOptionStd("theora");
+}
+
+ImageTransportHintsProperty::~ImageTransportHintsProperty() {}
+
+image_transport::TransportHints ImageTransportHintsProperty::getTransportHints() {
+  return image_transport::TransportHints(getStdString());
+}
+
+}

--- a/jsk_rviz_plugins/src/image_transport_hints_property.h
+++ b/jsk_rviz_plugins/src/image_transport_hints_property.h
@@ -1,0 +1,21 @@
+#ifndef JSK_RVIZ_PLUGINS_IMAGE_TRANSPORT_HINTS_PROPERTY_H
+#define JSK_RVIZ_PLUGINS_IMAGE_TRANSPORT_HINTS_PROPERTY_H
+
+#include <rviz/properties/property.h>
+#include <rviz/properties/editable_enum_property.h>
+#include <image_transport/transport_hints.h>
+
+namespace jsk_rviz_plugins {
+
+class ImageTransportHintsProperty : public rviz::EditableEnumProperty
+{
+  Q_OBJECT
+ public:
+  ImageTransportHintsProperty(const char* name, const char* description,
+                              rviz::Property* parent, const char* changed_slot);
+  ~ImageTransportHintsProperty();
+
+  image_transport::TransportHints getTransportHints();
+};
+}
+#endif

--- a/jsk_rviz_plugins/src/overlay_image_display.cpp
+++ b/jsk_rviz_plugins/src/overlay_image_display.cpp
@@ -58,13 +58,9 @@ namespace jsk_rviz_plugins
       ros::message_traits::datatype<sensor_msgs::Image>(),
       "sensor_msgs::Image topic to subscribe to.",
       this, SLOT( updateTopic() ));
-    transport_hint_property_ = new rviz::EditableEnumProperty("transport hint", "raw",
+    transport_hint_property_ = new ImageTransportHintsProperty("transport hint",
                                                               "transport hint to subscribe topic",
                                                               this, SLOT(updateTopic()));
-    transport_hint_property_->addOptionStd("raw");
-    // whell known image transports
-    transport_hint_property_->addOptionStd("compressed");
-    transport_hint_property_->addOptionStd("theora");
     keep_aspect_ratio_property_ = new rviz::BoolProperty("keep aspect ratio", false,
                                                          "keep aspect ratio of original image",
                                                          this, SLOT(updateKeepAspectRatio()));
@@ -137,7 +133,8 @@ namespace jsk_rviz_plugins
     std::string topic_name = update_topic_property_->getTopicStd();
     
     if (topic_name.length() > 0 && topic_name != "/") {
-      const image_transport::TransportHints transport_hint(transport_hint_property_->getStdString());
+      const image_transport::TransportHints transport_hint =
+        transport_hint_property_->getTransportHints();
       sub_ = it_->subscribe(topic_name, 1, &OverlayImageDisplay::processMessage, this,
                             transport_hint);
     }

--- a/jsk_rviz_plugins/src/overlay_image_display.cpp
+++ b/jsk_rviz_plugins/src/overlay_image_display.cpp
@@ -58,6 +58,13 @@ namespace jsk_rviz_plugins
       ros::message_traits::datatype<sensor_msgs::Image>(),
       "sensor_msgs::Image topic to subscribe to.",
       this, SLOT( updateTopic() ));
+    transport_hint_property_ = new rviz::EditableEnumProperty("transport hint", "raw",
+                                                              "transport hint to subscribe topic",
+                                                              this, SLOT(updateTopic()));
+    transport_hint_property_->addOptionStd("raw");
+    // whell known image transports
+    transport_hint_property_->addOptionStd("compressed");
+    transport_hint_property_->addOptionStd("theora");
     keep_aspect_ratio_property_ = new rviz::BoolProperty("keep aspect ratio", false,
                                                          "keep aspect ratio of original image",
                                                          this, SLOT(updateKeepAspectRatio()));
@@ -81,6 +88,7 @@ namespace jsk_rviz_plugins
   OverlayImageDisplay::~OverlayImageDisplay()
   {
     delete update_topic_property_;
+    delete transport_hint_property_;
     delete keep_aspect_ratio_property_;
     delete width_property_;
     delete height_property_;
@@ -129,7 +137,9 @@ namespace jsk_rviz_plugins
     std::string topic_name = update_topic_property_->getTopicStd();
     
     if (topic_name.length() > 0 && topic_name != "/") {
-      sub_ = it_->subscribe(topic_name, 1, &OverlayImageDisplay::processMessage, this);
+      const image_transport::TransportHints transport_hint(transport_hint_property_->getStdString());
+      sub_ = it_->subscribe(topic_name, 1, &OverlayImageDisplay::processMessage, this,
+                            transport_hint);
     }
   }
 

--- a/jsk_rviz_plugins/src/overlay_image_display.h
+++ b/jsk_rviz_plugins/src/overlay_image_display.h
@@ -47,6 +47,7 @@
 #include <rviz/properties/int_property.h>
 #include <rviz/properties/float_property.h>
 #include <rviz/properties/bool_property.h>
+#include <rviz/properties/editable_enum_property.h>
 
 #include <image_transport/image_transport.h>
 #include <sensor_msgs/Image.h>
@@ -74,6 +75,7 @@ namespace jsk_rviz_plugins
     boost::mutex mutex_;
     OverlayObject::Ptr overlay_;
     rviz::RosTopicProperty* update_topic_property_;
+    rviz::EditableEnumProperty* transport_hint_property_;
     rviz::BoolProperty* keep_aspect_ratio_property_;
     rviz::IntProperty* width_property_;
     rviz::IntProperty* height_property_;

--- a/jsk_rviz_plugins/src/overlay_image_display.h
+++ b/jsk_rviz_plugins/src/overlay_image_display.h
@@ -53,6 +53,7 @@
 #include <sensor_msgs/Image.h>
 
 #include "overlay_utils.h"
+#include "image_transport_hints_property.h"
 #endif
 
 namespace jsk_rviz_plugins
@@ -75,7 +76,7 @@ namespace jsk_rviz_plugins
     boost::mutex mutex_;
     OverlayObject::Ptr overlay_;
     rviz::RosTopicProperty* update_topic_property_;
-    rviz::EditableEnumProperty* transport_hint_property_;
+    ImageTransportHintsProperty* transport_hint_property_;
     rviz::BoolProperty* keep_aspect_ratio_property_;
     rviz::IntProperty* width_property_;
     rviz::IntProperty* height_property_;


### PR DESCRIPTION
This PR includes https://github.com/jsk-ros-pkg/jsk_visualization/pull/730

* Add field to choose transport hints for CameraInfo display.
* Add ImageTransportHintsProperty class to share code with CameraInfoDisplay and OverlayImageDisplay.

<img width="180" alt="スクリーンショット 2019-04-18 0 29 54" src="https://user-images.githubusercontent.com/40454/56300577-2a46ea00-6171-11e9-907d-05a37592b3a6.png">
