### PR TITLE
[jsk_rviz_plugins/OverlayImageDisplay] Use memcpy to copy image data

### DIFF
--- a/jsk_rviz_plugins/src/overlay_image_display.cpp
+++ b/jsk_rviz_plugins/src/overlay_image_display.cpp
@@ -188,7 +188,6 @@ namespace jsk_rviz_plugins
 
   void OverlayImageDisplay::redraw()
   {
-    cv_bridge::CvImagePtr cv_ptr;
     try
     {
       if (msg_->width == 0 || msg_->height == 0) {
@@ -196,36 +195,34 @@ namespace jsk_rviz_plugins
         // but they are not when input image width/height is 0
         return;
       }
-      else if (msg_->encoding == sensor_msgs::image_encodings::RGBA8 ||
-          msg_->encoding == sensor_msgs::image_encodings::BGRA8) {
-        cv_ptr = cv_bridge::toCvCopy(msg_, sensor_msgs::image_encodings::RGBA8);
-        cv::Mat mat = cv_ptr->image;
-        ScopedPixelBuffer buffer = overlay_->getBuffer();
-        QImage Hud = buffer.getQImage(*overlay_);
-        for (int i = 0; i < overlay_->getTextureWidth(); i++) {
-          for (int j = 0; j < overlay_->getTextureHeight(); j++) {
-            QColor color(mat.data[j * mat.step + i * mat.elemSize() + 0],
-                         mat.data[j * mat.step + i * mat.elemSize() + 1],
-                         mat.data[j * mat.step + i * mat.elemSize() + 2],
-                         mat.data[j * mat.step + i * mat.elemSize() + 3]);
-            Hud.setPixel(i, j, color.rgba());
-          }
-        }
-      }
       else {
-        cv_ptr = cv_bridge::toCvCopy(msg_, sensor_msgs::image_encodings::RGB8);
-        cv::Mat mat = cv_ptr->image;
+        cv::Mat mat;  // mat should be BGRA8 image
+
+        if (msg_->encoding == sensor_msgs::image_encodings::BGRA8 ||
+            msg_->encoding == sensor_msgs::image_encodings::RGBA8) {
+          const cv_bridge::CvImagePtr cv_ptr = cv_bridge::toCvCopy(
+                  msg_, sensor_msgs::image_encodings::BGRA8);
+          cv_ptr->image.copyTo(mat);
+        } else {
+            // If the image does not have alpha channel, use alpha_ value.
+            const cv_bridge::CvImagePtr cv_ptr =
+                    cv_bridge::toCvCopy(msg_, sensor_msgs::image_encodings::BGR8);
+            const cv::Mat bgr_image = cv_ptr->image;
+            std::vector<cv::Mat> channels;
+            // Split BGR image to each channel because cv::merge requires 4 images to create
+            // B-G-R-A image. The each 4 image represents each channel.
+            cv::split(bgr_image, channels);
+            // Create single alpha channel image
+            const cv::Mat alpha(bgr_image.rows, bgr_image.cols, CV_8UC1,
+                                cv::Scalar(alpha_ * 255.0));
+            channels.push_back(alpha);
+            cv::merge(channels, mat);
+        }
+
         ScopedPixelBuffer buffer = overlay_->getBuffer();
         QImage Hud = buffer.getQImage(*overlay_);
-        for (int i = 0; i < overlay_->getTextureWidth(); i++) {
-          for (int j = 0; j < overlay_->getTextureHeight(); j++) {
-            QColor color(mat.data[j * mat.step + i * mat.elemSize() + 0],
-                         mat.data[j * mat.step + i * mat.elemSize() + 1],
-                         mat.data[j * mat.step + i * mat.elemSize() + 2],
-                         alpha_ * 255.0);
-            Hud.setPixel(i, j, color.rgba());
-          }
-        }
+        // QImage created from ScopedPixelBuffer has no padding between each line.
+        memcpy(Hud.scanLine(0), mat.data, mat.cols * mat.rows * mat.elemSize());
       }
     }
     catch (cv_bridge::Exception& e)


### PR DESCRIPTION
* Use memcpy to copy image data from cv::Mat to QImagee instead of use
  QImage::setPixel() many times for optimization.