### PR TITLE
support jsk_rviz_plugin to be loaded in indigo

### DIFF
--- a/jsk_rviz_plugins/CMakeLists.txt
+++ b/jsk_rviz_plugins/CMakeLists.txt
@@ -4,7 +4,9 @@
 # http://ros.org/doc/groovy/api/catkin/html/user_guide/supposed.html
 cmake_minimum_required(VERSION 2.8.3)
 project(jsk_rviz_plugins)
-add_compile_options(-std=c++11)
+if("$ENV{ROS_DISTRO}" STRGREATER "indigo")
+  add_compile_options(-std=c++11)
+endif()
 # Load catkin and all dependencies required for this package
 # TODO: remove all from COMPONENTS that are not catkin packages.
 find_package(catkin REQUIRED COMPONENTS rviz jsk_hark_msgs jsk_footstep_msgs jsk_recognition_utils

--- a/jsk_rviz_plugins/src/ambient_sound_display_groovy.cpp
+++ b/jsk_rviz_plugins/src/ambient_sound_display_groovy.cpp
@@ -234,7 +234,11 @@ namespace jsk_rviz_plugins
 
         // We are keeping a circular buffer of visual pointers.  This gets
         // the next one, or creates and stores it if it was missing.
+#if ROS_VERSION_MINIMUM(1,12,0)
         std::shared_ptr<AmbientSoundVisual> visual;
+#else
+        boost::shared_ptr<AmbientSoundVisual> visual;
+#endif
         //AmbientSoundVisual* visual_ptr;
         if( visuals_.full())
         {

--- a/jsk_rviz_plugins/src/ambient_sound_display_groovy.h
+++ b/jsk_rviz_plugins/src/ambient_sound_display_groovy.h
@@ -10,6 +10,8 @@
 #include <rviz/message_filter_display.h>
 #endif
 
+#include <ros/ros.h>
+
 namespace Ogre
 {
 class SceneNode;
@@ -109,7 +111,11 @@ private:
   // adjustable history length, so we need one visual per history
   // item.
   //boost::circular_buffer<AmbientSoundVisual*> visuals_;
+#if ROS_VERSION_MINIMUM(1,12,0)
   boost::circular_buffer<std::shared_ptr<AmbientSoundVisual> > visuals_;
+#else
+  boost::circular_buffer<boost::shared_ptr<AmbientSoundVisual> > visuals_;
+#endif
 
   // A node in the Ogre scene tree to be the parent of all our visuals.
   //Ogre::SceneNode* scene_node_;

--- a/jsk_rviz_plugins/src/bounding_box_display_common.h
+++ b/jsk_rviz_plugins/src/bounding_box_display_common.h
@@ -59,9 +59,15 @@ namespace jsk_rviz_plugins
 public:
     BoundingBoxDisplayCommon() {};
     ~BoundingBoxDisplayCommon() {};
+#if ROS_VERSION_MINIMUM(1,12,0)
     typedef std::shared_ptr<rviz::Shape> ShapePtr;
     typedef std::shared_ptr<rviz::BillboardLine> BillboardLinePtr;
     typedef std::shared_ptr<rviz::Arrow> ArrowPtr;
+#else
+    typedef boost::shared_ptr<rviz::Shape> ShapePtr;
+    typedef boost::shared_ptr<rviz::BillboardLine> BillboardLinePtr;
+    typedef boost::shared_ptr<rviz::Arrow> ArrowPtr;
+#endif
 
 protected:
     QColor color_;

--- a/jsk_rviz_plugins/src/camera_info_display.h
+++ b/jsk_rviz_plugins/src/camera_info_display.h
@@ -64,7 +64,11 @@ namespace jsk_rviz_plugins
   class TrianglePolygon
   {
   public:
+#if ROS_VERSION_MINIMUM(1,12,0)
     typedef std::shared_ptr<TrianglePolygon> Ptr;
+#else
+    typedef boost::shared_ptr<TrianglePolygon> Ptr;
+#endif
     TrianglePolygon(Ogre::SceneManager* manager,
                     Ogre::SceneNode* node,
                     const cv::Point3d& O,
@@ -87,8 +91,13 @@ namespace jsk_rviz_plugins
   {
     Q_OBJECT
   public:
+#if ROS_VERSION_MINIMUM(1,12,0)
     typedef std::shared_ptr<rviz::Shape> ShapePtr;
     typedef std::shared_ptr<rviz::BillboardLine> BillboardLinePtr;
+#else
+    typedef boost::shared_ptr<rviz::Shape> ShapePtr;
+    typedef boost::shared_ptr<rviz::BillboardLine> BillboardLinePtr;
+#endif
     CameraInfoDisplay();
     virtual ~CameraInfoDisplay();
     

--- a/jsk_rviz_plugins/src/facing_visualizer.h
+++ b/jsk_rviz_plugins/src/facing_visualizer.h
@@ -57,7 +57,11 @@ namespace jsk_rviz_plugins
   class SquareObject
   {
   public:
+#if ROS_VERSION_MINIMUM(1,12,0)
     typedef std::shared_ptr<SquareObject> Ptr;
+#else
+    typedef boost::shared_ptr<SquareObject> Ptr;
+#endif
     SquareObject(Ogre::SceneManager* manager,
                  double outer_radius,
                  double inner_radius,
@@ -86,7 +90,11 @@ namespace jsk_rviz_plugins
   class TextureObject           // utility class for texture
   {
   public:
+#if ROS_VERSION_MINIMUM(1,12,0)
     typedef std::shared_ptr<TextureObject> Ptr;
+#else
+    typedef boost::shared_ptr<TextureObject> Ptr;
+#endif
     TextureObject(const int width, const int height, const std::string name);
     virtual ~TextureObject();
     virtual int getWidth() { return width_; };
@@ -106,7 +114,11 @@ namespace jsk_rviz_plugins
   class FacingObject
   {
   public:
+#if ROS_VERSION_MINIMUM(1,12,0)
     typedef std::shared_ptr<FacingObject> Ptr;
+#else
+    typedef boost::shared_ptr<FacingObject> Ptr;
+#endif
     FacingObject(Ogre::SceneManager* manager,
                  Ogre::SceneNode* parent,
                  double size);
@@ -137,7 +149,11 @@ namespace jsk_rviz_plugins
   class SimpleCircleFacingVisualizer: public FacingObject
   {
   public:
+#if ROS_VERSION_MINIMUM(1,12,0)
     typedef std::shared_ptr<SimpleCircleFacingVisualizer> Ptr;
+#else
+    typedef boost::shared_ptr<SimpleCircleFacingVisualizer> Ptr;
+#endif
     SimpleCircleFacingVisualizer(Ogre::SceneManager* manager,
                                  Ogre::SceneNode* parent,
                                  rviz::DisplayContext* context,
@@ -184,7 +200,11 @@ namespace jsk_rviz_plugins
   class FacingTexturedObject: public FacingObject
   {
   public:
+#if ROS_VERSION_MINIMUM(1,12,0)
     typedef std::shared_ptr<FacingTexturedObject> Ptr;
+#else
+    typedef boost::shared_ptr<FacingTexturedObject> Ptr;
+#endif
     FacingTexturedObject(Ogre::SceneManager* manager,
                          Ogre::SceneNode* parent,
                          double size);
@@ -200,7 +220,11 @@ namespace jsk_rviz_plugins
   class GISCircleVisualizer: public FacingTexturedObject
   {
   public:
+#if ROS_VERSION_MINIMUM(1,12,0)
     typedef std::shared_ptr<GISCircleVisualizer> Ptr;
+#else
+    typedef boost::shared_ptr<GISCircleVisualizer> Ptr;
+#endif
     GISCircleVisualizer(Ogre::SceneManager* manager,
                         Ogre::SceneNode* parent,
                         double size,

--- a/jsk_rviz_plugins/src/footstep_display.h
+++ b/jsk_rviz_plugins/src/footstep_display.h
@@ -75,7 +75,11 @@ namespace jsk_rviz_plugins
     rviz::BoolProperty* show_name_property_;
     rviz::BoolProperty* use_group_coloring_property_;
     jsk_footstep_msgs::FootstepArray::ConstPtr latest_footstep_;
+#if ROS_VERSION_MINIMUM(1,12,0)
     typedef std::shared_ptr<rviz::Shape> ShapePtr;
+#else
+    typedef boost::shared_ptr<rviz::Shape> ShapePtr;
+#endif
     std::vector<ShapePtr> shapes_;
     std::vector<rviz::MovableText*> texts_;
     std::vector<Ogre::SceneNode*> text_nodes_;

--- a/jsk_rviz_plugins/src/normal_display.cpp
+++ b/jsk_rviz_plugins/src/normal_display.cpp
@@ -232,7 +232,11 @@ namespace jsk_rviz_plugins
 
         if (validateFloats(Ogre::Vector3(x, y, z)) && validateFloats(Ogre::Vector3(normal_x, normal_y, normal_z)))
           {
+#if ROS_VERSION_MINIMUM(1,12,0)
             std::shared_ptr<NormalVisual> visual;
+#else
+            boost::shared_ptr<NormalVisual> visual;
+#endif
             if(visuals_.full()){
               visual = visuals_.front();
             }else{

--- a/jsk_rviz_plugins/src/normal_display.h
+++ b/jsk_rviz_plugins/src/normal_display.h
@@ -56,7 +56,12 @@ protected:
 
   virtual void reset();
 
+#if ROS_VERSION_MINIMUM(1,12,0)
   boost::circular_buffer<std::shared_ptr<NormalVisual> > visuals_;
+#else
+  boost::circular_buffer<boost::shared_ptr<NormalVisual> > visuals_;
+#endif
+
 
   // Function to handle an incoming ROS message.
 private Q_SLOTS:

--- a/jsk_rviz_plugins/src/normal_visual.h
+++ b/jsk_rviz_plugins/src/normal_visual.h
@@ -9,6 +9,7 @@
 #include <rviz/ogre_helpers/arrow.h>
 #include <geometry_msgs/Vector3.h>
 #include <sensor_msgs/PointCloud2.h>
+#include <ros/ros.h>
 
 namespace jsk_rviz_plugins
 {
@@ -27,7 +28,11 @@ namespace jsk_rviz_plugins
     void setScale( float scale );
 
   private:
+#if ROS_VERSION_MINIMUM(1,12,0)
     std::shared_ptr<rviz::Arrow> normal_arrow_;
+#else
+    boost::shared_ptr<rviz::Arrow> normal_arrow_;
+#endif
     Ogre::SceneNode* frame_node_;
     Ogre::SceneManager* scene_manager_;
   };

--- a/jsk_rviz_plugins/src/overlay_diagnostic_display.cpp
+++ b/jsk_rviz_plugins/src/overlay_diagnostic_display.cpp
@@ -148,8 +148,13 @@ namespace jsk_rviz_plugins
     for (size_t i = 0; i < msg->status.size(); i++) {
       diagnostic_msgs::DiagnosticStatus status = msg->status[i];
       if (status.name == diagnostics_namespace_) {
+#if ROS_VERSION_MINIMUM(1,12,0)
         latest_status_
           = std::make_shared<diagnostic_msgs::DiagnosticStatus>(status);
+#else
+        latest_status_
+          = boost::make_shared<diagnostic_msgs::DiagnosticStatus>(status);
+#endif
         latest_message_time_ = ros::WallTime::now();
         break;
       }

--- a/jsk_rviz_plugins/src/overlay_diagnostic_display.h
+++ b/jsk_rviz_plugins/src/overlay_diagnostic_display.h
@@ -115,7 +115,11 @@ namespace jsk_rviz_plugins
     boost::mutex mutex_;
     OverlayObject::Ptr overlay_;
     
+#if ROS_VERSION_MINIMUM(1,12,0)
     std::shared_ptr<diagnostic_msgs::DiagnosticStatus> latest_status_;
+#else
+    boost::shared_ptr<diagnostic_msgs::DiagnosticStatus> latest_status_;
+#endif
     State previous_state_;
     ros::WallTime latest_message_time_;
     ros::WallTime animation_start_time_;

--- a/jsk_rviz_plugins/src/overlay_image_display.cpp
+++ b/jsk_rviz_plugins/src/overlay_image_display.cpp
@@ -96,7 +96,11 @@ namespace jsk_rviz_plugins
   void OverlayImageDisplay::onInitialize()
   {
     ros::NodeHandle nh;
+#if ROS_VERSION_MINIMUM(1,12,0)
     it_ = std::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(nh));
+#else
+    it_ = boost::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(nh));
+#endif
 
     updateWidth();
     updateHeight();

--- a/jsk_rviz_plugins/src/overlay_image_display.h
+++ b/jsk_rviz_plugins/src/overlay_image_display.h
@@ -85,7 +85,11 @@ namespace jsk_rviz_plugins
     rviz::FloatProperty* alpha_property_;
     int width_, height_, left_, top_;
     double alpha_;
+#if ROS_VERSION_MINIMUM(1,12,0)
     std::shared_ptr<image_transport::ImageTransport> it_;
+#else
+    boost::shared_ptr<image_transport::ImageTransport> it_;
+#endif
     image_transport::Subscriber sub_;
     sensor_msgs::Image::ConstPtr msg_;
     bool is_msg_available_;

--- a/jsk_rviz_plugins/src/overlay_utils.h
+++ b/jsk_rviz_plugins/src/overlay_utils.h
@@ -59,6 +59,8 @@
 #include <QImage>
 #include <QColor>
 
+#include <ros/ros.h>
+
 namespace jsk_rviz_plugins
 {
   class OverlayObject;
@@ -86,7 +88,11 @@ namespace jsk_rviz_plugins
   class OverlayObject
   {
   public:
+#if ROS_VERSION_MINIMUM(1,12,0)
     typedef std::shared_ptr<OverlayObject> Ptr;
+#else
+    typedef boost::shared_ptr<OverlayObject> Ptr;
+#endif
     
     OverlayObject(const std::string& name);
     virtual ~OverlayObject();

--- a/jsk_rviz_plugins/src/pictogram_display.h
+++ b/jsk_rviz_plugins/src/pictogram_display.h
@@ -68,7 +68,11 @@ namespace jsk_rviz_plugins
   class PictogramObject: public FacingTexturedObject
   {
   public:
+#if ROS_VERSION_MINIMUM(1,12,0)
     typedef std::shared_ptr<PictogramObject> Ptr;
+#else
+    typedef boost::shared_ptr<PictogramObject> Ptr;
+#endif
     PictogramObject(Ogre::SceneManager* manager,
                     Ogre::SceneNode* parent,
                     double size);

--- a/jsk_rviz_plugins/src/polygon_array_display.h
+++ b/jsk_rviz_plugins/src/polygon_array_display.h
@@ -53,6 +53,8 @@
 #include <rviz/ogre_helpers/arrow.h>
 #endif
 
+#include <ros/ros.h>
+
 namespace jsk_rviz_plugins
 {
   
@@ -61,7 +63,11 @@ namespace jsk_rviz_plugins
   {
     Q_OBJECT
   public:
+#if ROS_VERSION_MINIMUM(1,12,0)
     typedef std::shared_ptr<rviz::Arrow> ArrowPtr;
+#else
+    typedef boost::shared_ptr<rviz::Arrow> ArrowPtr;
+#endif
     PolygonArrayDisplay();
     virtual ~PolygonArrayDisplay();
   protected:

--- a/jsk_rviz_plugins/src/segment_array_display.h
+++ b/jsk_rviz_plugins/src/segment_array_display.h
@@ -56,7 +56,11 @@ namespace jsk_rviz_plugins
   {
     Q_OBJECT
   public:
+#if ROS_VERSION_MINIMUM(1,12,0)
     typedef std::shared_ptr<rviz::BillboardLine> BillboardLinePtr;
+#else
+    typedef boost::shared_ptr<rviz::BillboardLine> BillboardLinePtr;
+#endif
     SegmentArrayDisplay();
     virtual ~SegmentArrayDisplay();
   protected:

--- a/jsk_rviz_plugins/src/simple_occupancy_grid_array_display.h
+++ b/jsk_rviz_plugins/src/simple_occupancy_grid_array_display.h
@@ -54,7 +54,11 @@ namespace jsk_rviz_plugins
   {
     Q_OBJECT
   public:
+#if ROS_VERSION_MINIMUM(1,12,0)
     typedef std::shared_ptr<rviz::PointCloud> PointCloudPtr;
+#else
+    typedef boost::shared_ptr<rviz::PointCloud> PointCloudPtr;
+#endif
     SimpleOccupancyGridArrayDisplay();
     virtual ~SimpleOccupancyGridArrayDisplay();
   protected:

--- a/jsk_rviz_plugins/src/torus_array_display.h
+++ b/jsk_rviz_plugins/src/torus_array_display.h
@@ -60,8 +60,13 @@ namespace jsk_rviz_plugins
   {
     Q_OBJECT
   public:
+#if ROS_VERSION_MINIMUM(1,12,0)
     typedef std::shared_ptr<rviz::Arrow> ArrowPtr;
     typedef std::shared_ptr<rviz::MeshShape> ShapePtr;
+#else
+    typedef boost::shared_ptr<rviz::Arrow> ArrowPtr;
+    typedef boost::shared_ptr<rviz::MeshShape> ShapePtr;
+#endif
     TorusArrayDisplay();
     virtual ~TorusArrayDisplay();
   protected:

--- a/jsk_rviz_plugins/src/twist_stamped_display.h
+++ b/jsk_rviz_plugins/src/twist_stamped_display.h
@@ -60,8 +60,13 @@ namespace jsk_rviz_plugins
   {
     Q_OBJECT
   public:
+#if ROS_VERSION_MINIMUM(1,12,0)
     typedef std::shared_ptr<rviz::Arrow> ArrowPtr;
     typedef std::shared_ptr<rviz::BillboardLine> BillboardLinePtr;
+#else
+    typedef boost::shared_ptr<rviz::Arrow> ArrowPtr;
+    typedef boost::shared_ptr<rviz::BillboardLine> BillboardLinePtr;
+#endif
     TwistStampedDisplay();
     virtual ~TwistStampedDisplay();
   protected:

--- a/jsk_rviz_plugins/src/video_capture_display.h
+++ b/jsk_rviz_plugins/src/video_capture_display.h
@@ -43,13 +43,19 @@
 #include <rviz/properties/float_property.h>
 #include <opencv2/opencv.hpp>
 
+#include <ros/ros.h>
+
 namespace jsk_rviz_plugins
 {
   class VideoCaptureDisplay: public rviz::Display
   {
     Q_OBJECT
   public:
+#if ROS_VERSION_MINIMUM(1,12,0)
     typedef std::shared_ptr<VideoCaptureDisplay> Ptr;
+#else
+    typedef boost::shared_ptr<VideoCaptureDisplay> Ptr;
+#endif
     VideoCaptureDisplay();
     virtual ~VideoCaptureDisplay();
   protected:


### PR DESCRIPTION
current `jsk_rviz_plugins` is built with C++11 with `std::shared_ptr`. (see #710)
This causes rviz load error and segmentation fault in Indigo. (see https://github.com/PointCloudLibrary/pcl/issues/619#ref-pullrequest-151717701)
I support to build old fashion style when ROS version is indigo.