### PR TITLE
[DO NOT MERGE YET] Remove unnecessary ROS_INFO used just for debug

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule ".travis"]
 	path = .travis
-	url = git://github.com/jsk-ros-pkg/jsk_travis
+	url = git://github.com/YutoUchimi/jsk_travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ notifications:
   slack: jsk-robotics:Av7tc8wj3IWkLYvlTzHE7x2g
 env:
   global:
-    - ROS_PARALLEL_JOBS='-j2'
+    - ROS_PARALLEL_JOBS='-j4'
     - USE_JENKINS=false
     - USE_TRAVIS=true
     - USE_DOCKER=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
   - source .travis/travis.sh
   # test building sphinx documentation
   - which virtualenv 2>/dev/null || pip install --user virtualenv
-  - (sudo su -c 'cd $TRAVIS_BUILD_DIR/doc && source setup.sh && make html')
+  - (cd $TRAVIS_BUILD_DIR/doc && source setup.sh && make html)
 after_success:
   # trigger build of jsk-docs.readthedocs.org
   - curl -X POST -d "branches=master" -d "token=da477cb4ef53d533aeb51c2b43e8baca6202baca" https://readthedocs.org/api/v2/webhook/jsk-docs/9094/

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
   - source .travis/travis.sh
   # test building sphinx documentation
   - which virtualenv 2>/dev/null || pip install --user virtualenv
-  - (cd $TRAVIS_BUILD_DIR/doc && source setup.sh && make html)
+  - (sudo su -c 'cd $TRAVIS_BUILD_DIR/doc && source setup.sh && make html')
 after_success:
   # trigger build of jsk-docs.readthedocs.org
   - curl -X POST -d "branches=master" -d "token=da477cb4ef53d533aeb51c2b43e8baca6202baca" https://readthedocs.org/api/v2/webhook/jsk-docs/9094/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: c++
 cache:
-  directories:
-    - $HOME/.ccache
-    - $HOME/.cache/pip
+  - ccache
+  - pip
 python:
   - "2.7"
 compiler:

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,4 @@
-sphinx
-sphinx-autobuild
-recommonmark
+recommonmark==0.5.0
+Sphinx==1.8.4
+sphinx-markdown-tables==0.0.9
+sphinx_rtd_theme==0.4.3

--- a/jsk_interactive_markers/jsk_interactive_marker/src/yaml_menu_handler.cpp
+++ b/jsk_interactive_markers/jsk_interactive_marker/src/yaml_menu_handler.cpp
@@ -3,7 +3,6 @@
 
 using namespace jsk_interactive_marker;
 YamlMenuHandler::YamlMenuHandler(ros::NodeHandle* node_ptr, std::string file_name) {
-  ROS_INFO("hoge %s ", file_name.c_str());
   _node_ptr = node_ptr;
   initMenu(file_name);
 }


### PR DESCRIPTION
`YamlMenuHandler` shows file name, but there is a doubled ROS_INFO apparently used only for debugging.

Edited: "doubled" means the file name is already shown in `initMenu` function.

https://github.com/jsk-ros-pkg/jsk_visualization/blob/51cfd594be94c4976cfca87d5c82b2654cf64a84/jsk_interactive_markers/jsk_interactive_marker/src/yaml_menu_handler.cpp#L15
https://github.com/jsk-ros-pkg/jsk_visualization/blob/51cfd594be94c4976cfca87d5c82b2654cf64a84/jsk_interactive_markers/jsk_interactive_marker/src/yaml_menu_handler.cpp#L28