### PR TITLE
[motor_states_temperature_decomposer.py]add queue_size

### DIFF
--- a/jsk_rviz_plugins/scripts/motor_states_temperature_decomposer.py
+++ b/jsk_rviz_plugins/scripts/motor_states_temperature_decomposer.py
@@ -19,13 +19,13 @@ def allocatePublishers(num):
     global g_publishers
     if num > len(g_publishers):
         for i in range(len(g_publishers), num):
-            pub = rospy.Publisher('temperature_%02d' % (i), Float32)
+            pub = rospy.Publisher('temperature_%02d' % (i), Float32, queue_size=1)
             g_publishers.append(pub)
 def allocateEffortPublishers(names):
     global g_effort_publishers
     for name in names:
         if not g_effort_publishers.has_key(name):
-            g_effort_publishers[name] = rospy.Publisher('effort_%s' % (name), Float32)
+            g_effort_publishers[name] = rospy.Publisher('effort_%s' % (name), Float32, queue_size=1)
         
 def motorStatesCallback(msg):
     global g_publishers, g_text_publisher
@@ -75,7 +75,7 @@ def jointStatesCallback(msg):
 if __name__ == "__main__":
     rospy.init_node("motor_state_temperature_decomposer")
     robot_model = URDF.from_xml_string(rospy.get_param("/robot_description"))
-    g_text_publisher = rospy.Publisher("max_temparature_text", OverlayText)
+    g_text_publisher = rospy.Publisher("max_temparature_text", OverlayText, queue_size=1)
     s = rospy.Subscriber("/motor_states", MotorStates, motorStatesCallback, queue_size=1)
     s_joint_states = rospy.Subscriber("/joint_states", JointState, jointStatesCallback, queue_size=1)
     #s = rospy.Subscriber("joint_states", MotorStates, motorStatesCallback)


### PR DESCRIPTION
以下のようなwariningを出ないようにするために、引数queue_sizeを追加しました。
queue_sizeはHydroで追加された引数です。

jsk_rviz_pluginには他にもqueue_sizeを指定せずにPublisherを立ち上げているコードがあるようです。

```
/opt/ros/kinetic/lib/jsk_rviz_plugins/motor_states_temperature_decomposer.py:78: SyntaxWarning: The publisher should be created with an explicit keyword argument 'queue_size'. Please see http://wiki.ros.org/rospy/Overview/Publishers%20and%20Subscribers for more information.
  g_text_publisher = rospy.Publisher("max_temparature_text", OverlayText)
/opt/ros/kinetic/lib/jsk_rviz_plugins/motor_states_temperature_decomposer.py:28: SyntaxWarning: The publisher should be created with an explicit keyword argument 'queue_size'. Please see http://wiki.ros.org/rospy/Overview/Publishers%20and%20Subscribers for more information.
  g_effort_publishers[name] = rospy.Publisher('effort_%s' % (name), Float32)
/opt/ros/kinetic/lib/jsk_rviz_plugins/motor_states_temperature_decomposer.py:22: SyntaxWarning: The publisher should be created with an explicit keyword argument 'queue_size'. Please see http://wiki.ros.org/rospy/Overview/Publishers%20and%20Subscribers for more information.
  pub = rospy.Publisher('temperature_%02d' % (i), Float32)
```