### PR TITLE
Add overtake position to OverlayMenu display on RViz

### DIFF
--- a/jsk_rviz_plugins/src/overlay_menu_display.cpp
+++ b/jsk_rviz_plugins/src/overlay_menu_display.cpp
@@ -353,12 +353,12 @@ namespace jsk_rviz_plugins
     }
     overlay_->setDimensions(overlay_->getTextureWidth(), overlay_->getTextureHeight());
     double window_left = left_;
-    if (window_left < 0) {
+    if (!overtake_position_properties_ || window_left < 0) {
       int window_width = context_->getViewManager()->getRenderPanel()->width();
       window_left = (window_width - (int)overlay_->getTextureWidth()) / 2.0;
     }
     double window_top = top_;
-    if (window_top < 0) {
+    if (!overtake_position_properties_ || window_top < 0) {
       int window_height = context_->getViewManager()->getRenderPanel()->height();
       window_top = (window_height - (int)overlay_->getTextureHeight()) / 2.0;
     }
@@ -418,12 +418,12 @@ namespace jsk_rviz_plugins
     }
     overlay_->setDimensions(overlay_->getTextureWidth(), overlay_->getTextureHeight());
     double window_left = left_;
-    if (window_left < 0) {
+    if (!overtake_position_properties_ || window_left < 0) {
       int window_width = context_->getViewManager()->getRenderPanel()->width();
       window_left = (window_width - (int)overlay_->getTextureWidth()) / 2.0;
     }
     double window_top = top_;
-    if (window_top < 0) {
+    if (!overtake_position_properties_ || window_top < 0) {
       int window_height = context_->getViewManager()->getRenderPanel()->height();
       window_top = (window_height - (int)overlay_->getTextureHeight()) / 2.0;
     }

--- a/jsk_rviz_plugins/src/overlay_menu_display.h
+++ b/jsk_rviz_plugins/src/overlay_menu_display.h
@@ -44,6 +44,8 @@
 #include <QPainter>
 
 #include <rviz/properties/ros_topic_property.h>
+#include <rviz/properties/bool_property.h>
+#include <rviz/properties/int_property.h>
 
 #include <jsk_rviz_plugins/OverlayMenu.h>
 
@@ -69,8 +71,17 @@ namespace jsk_rviz_plugins
     
   protected:
     OverlayObject::Ptr overlay_;
+    bool overtake_position_properties_;
+    int left_;
+    int top_;
+
     ros::Subscriber sub_;
+
     rviz::RosTopicProperty* update_topic_property_;
+    rviz::BoolProperty* overtake_position_properties_property_;
+    rviz::IntProperty* top_property_;
+    rviz::IntProperty* left_property_;
+
     AnimationState animation_state_;
     bool require_update_texture_;
     jsk_rviz_plugins::OverlayMenu::ConstPtr current_menu_;
@@ -100,7 +111,9 @@ namespace jsk_rviz_plugins
     (const jsk_rviz_plugins::OverlayMenu::ConstPtr& msg);
   protected Q_SLOTS:
     void updateTopic();
-    
+    void updateOvertakePositionProperties();
+    void updateTop();
+    void updateLeft();
   };
 
 }


### PR DESCRIPTION
RViz display for OverlayMenu was fixed at the middle of the window.
This PR allows user to modify the top/left position of menu from RViz by checking the `Overtake Position` box.

![overtake](https://user-images.githubusercontent.com/3526294/73812780-5d05c000-4821-11ea-83f9-1b2617214d16.png)

User can still align middle by setting the top/left value to `-1`

![overtake_default](https://user-images.githubusercontent.com/3526294/73812767-4e1f0d80-4821-11ea-97a6-f2551fcef8a1.png)

This PR can be tested by running the existing sample

```
roslaunch jsk_rviz_plugins overlay_sample.launch 
```