### PR TITLE
Update jsk_travis to 0.5.7

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,4 @@
-sphinx
-sphinx-autobuild
-recommonmark
+recommonmark==0.5.0
+Sphinx==1.8.4
+sphinx-markdown-tables==0.0.9
+sphinx_rtd_theme==0.4.3


### PR DESCRIPTION
Travis build of #758 is failing.
From https://travis-ci.org/jsk-ros-pkg/jsk_visualization/jobs/647611272#L1500
```
++ sudo apt-get update -q
Ign https://esm.ubuntu.com trusty-infra-security InRelease
Ign https://esm.ubuntu.com trusty-infra-updates InRelease
Ign https://esm.ubuntu.com trusty-infra-security Release.gpg
Ign https://esm.ubuntu.com trusty-infra-updates Release.gpg
Ign https://esm.ubuntu.com trusty-infra-security Release
Ign https://esm.ubuntu.com trusty-infra-updates Release
Err https://esm.ubuntu.com trusty-infra-security/main amd64 Packages
  Received HTTP code 403 from proxy after CONNECT
Err https://esm.ubuntu.com trusty-infra-updates/main amd64 Packages
  Received HTTP code 403 from proxy after CONNECT
Get:1 http://packages.ros.org trusty InRelease [4669 B]
Get:2 http://packages.ros.org trusty/main amd64 Packages [624 kB]
Ign http://archive.ubuntu.com trusty InRelease
Hit http://security.ubuntu.com trusty-security InRelease
Hit http://archive.ubuntu.com trusty-updates InRelease
Hit http://security.ubuntu.com trusty-security/main amd64 Packages
Hit http://archive.ubuntu.com trusty-backports InRelease
Hit http://archive.ubuntu.com trusty Release.gpg
Hit http://security.ubuntu.com trusty-security/restricted amd64 Packages
Hit http://archive.ubuntu.com trusty-updates/main amd64 Packages
Hit http://security.ubuntu.com trusty-security/universe amd64 Packages
Hit http://archive.ubuntu.com trusty-updates/restricted amd64 Packages
Hit http://archive.ubuntu.com trusty-updates/universe amd64 Packages
Hit http://security.ubuntu.com trusty-security/multiverse amd64 Packages
Hit http://archive.ubuntu.com trusty-updates/multiverse amd64 Packages
Hit http://archive.ubuntu.com trusty-backports/main amd64 Packages
Hit http://archive.ubuntu.com trusty-backports/restricted amd64 Packages
Hit http://archive.ubuntu.com trusty-backports/universe amd64 Packages
Hit http://archive.ubuntu.com trusty-backports/multiverse amd64 Packages
Hit http://archive.ubuntu.com trusty Release
Hit http://archive.ubuntu.com trusty/main amd64 Packages
Hit http://archive.ubuntu.com trusty/restricted amd64 Packages
Hit http://archive.ubuntu.com trusty/universe amd64 Packages
Hit http://archive.ubuntu.com trusty/multiverse amd64 Packages
Fetched 628 kB in 4s (130 kB/s)
W: Failed to fetch https://esm.ubuntu.com/ubuntu/dists/trusty-infra-security/main/binary-amd64/Packages  Received HTTP code 403 from proxy after CONNECT
W: Failed to fetch https://esm.ubuntu.com/ubuntu/dists/trusty-infra-updates/main/binary-amd64/Packages  Received HTTP code 403 from proxy after CONNECT
E: Some index files failed to download. They have been ignored, or old ones used instead.
```

This is the same problem reported in https://github.com/jsk-ros-pkg/jsk_travis/pull/388 and fixed in jsk_travis>=0.5.6