### PR TITLE
Run after clang compile

### DIFF
--- a/jsk_rviz_plugins/src/bounding_box_display_common.h
+++ b/jsk_rviz_plugins/src/bounding_box_display_common.h
@@ -112,10 +112,8 @@ protected:
                         ros_color.b * 255.0,
                         ros_color.a * 255.0);
         }
-        else {
-          return QColor(255.0, 255.0, 255.0, 255.0);
-        }
-      }
+      }  
+      return QColor(255.0, 255.0, 255.0, 255.0);
     }
 
     bool isValidBoundingBox(

--- a/jsk_rviz_plugins/src/overlay_diagnostic_display.cpp
+++ b/jsk_rviz_plugins/src/overlay_diagnostic_display.cpp
@@ -112,7 +112,7 @@ namespace jsk_rviz_plugins
   void OverlayDiagnosticDisplay::processMessage(
     const diagnostic_msgs::DiagnosticArray::ConstPtr& msg)
   {
-    boost::mutex::scoped_lock(mutex_);
+    boost::mutex::scoped_lock lock(mutex_);
     //std::make_shared<diagnostic_msgs::DiagnosticStatus>
     // update namespaces_ if needed
     std::set<std::string> new_namespaces;
@@ -163,7 +163,7 @@ namespace jsk_rviz_plugins
 
   void OverlayDiagnosticDisplay::update(float wall_dt, float ros_dt)
   {
-    boost::mutex::scoped_lock(mutex_);
+    boost::mutex::scoped_lock lock(mutex_);
     if (!isEnabled()) {
       return;
     }

--- a/jsk_rviz_plugins/src/overlay_image_display.cpp
+++ b/jsk_rviz_plugins/src/overlay_image_display.cpp
@@ -155,7 +155,7 @@ namespace jsk_rviz_plugins
   void OverlayImageDisplay::processMessage(
     const sensor_msgs::Image::ConstPtr& msg)
   {
-    boost::mutex::scoped_lock(mutex_);
+    boost::mutex::scoped_lock lock(mutex_);
     msg_ = msg;
     is_msg_available_ = true;
     require_update_ = true;
@@ -169,7 +169,7 @@ namespace jsk_rviz_plugins
 
   void OverlayImageDisplay::update(float wall_dt, float ros_dt)
   {
-    boost::mutex::scoped_lock(mutex_);
+    boost::mutex::scoped_lock lock(mutex_);
 
     if (!isEnabled()) {
       return;

--- a/jsk_rviz_plugins/src/overlay_text_display.cpp
+++ b/jsk_rviz_plugins/src/overlay_text_display.cpp
@@ -229,7 +229,7 @@ namespace jsk_rviz_plugins
       QImage Hud = buffer.getQImage(*overlay_, bg_color_);
       QPainter painter( &Hud );
       painter.setRenderHint(QPainter::Antialiasing, true);
-      painter.setPen(QPen(fg_color_, line_width_ || 1, Qt::SolidLine));
+      painter.setPen(QPen(fg_color_, std::max(line_width_,1), Qt::SolidLine));
       uint16_t w = overlay_->getTextureWidth();
       uint16_t h = overlay_->getTextureHeight();
 

--- a/jsk_rviz_plugins/src/overlay_utils.cpp
+++ b/jsk_rviz_plugins/src/overlay_utils.cpp
@@ -139,7 +139,7 @@ namespace jsk_rviz_plugins
     return !texture_.isNull();
   }
 
-  bool OverlayObject::updateTextureSize(unsigned int width, unsigned int height)
+  void OverlayObject::updateTextureSize(unsigned int width, unsigned int height)
   {
     const std::string texture_name = name_ + "Texture";
     if (width == 0) {

--- a/jsk_rviz_plugins/src/overlay_utils.h
+++ b/jsk_rviz_plugins/src/overlay_utils.h
@@ -101,7 +101,7 @@ namespace jsk_rviz_plugins
     virtual void hide();
     virtual void show();
     virtual bool isTextureReady();
-    virtual bool updateTextureSize(unsigned int width, unsigned int height);
+    virtual void updateTextureSize(unsigned int width, unsigned int height);
     virtual ScopedPixelBuffer getBuffer();
     virtual void setPosition(double left, double top);
     virtual void setDimensions(double width, double height);

--- a/jsk_rviz_plugins/src/pictogram_array_display.cpp
+++ b/jsk_rviz_plugins/src/pictogram_array_display.cpp
@@ -95,7 +95,7 @@ namespace jsk_rviz_plugins
   void PictogramArrayDisplay::processMessage(
     const jsk_rviz_plugins::PictogramArray::ConstPtr& msg)
   {
-    boost::mutex::scoped_lock (mutex_);
+    boost::mutex::scoped_lock lock(mutex_);
     allocatePictograms(msg->pictograms.size());
     for (size_t i = 0; i < pictograms_.size(); i++) {
       pictograms_[i]->setEnable(isEnabled());
@@ -131,7 +131,7 @@ namespace jsk_rviz_plugins
 
   void PictogramArrayDisplay::update(float wall_dt, float ros_dt)
   {
-    boost::mutex::scoped_lock (mutex_);
+    boost::mutex::scoped_lock lock(mutex_);
     for (size_t i = 0; i < pictograms_.size(); i++) {
       pictograms_[i]->update(wall_dt, ros_dt);
     }

--- a/jsk_rviz_plugins/src/pictogram_display.cpp
+++ b/jsk_rviz_plugins/src/pictogram_display.cpp
@@ -61,10 +61,8 @@ namespace jsk_rviz_plugins
     if (id == -1) {
       ROS_WARN("failed to load font");
     }
-    else {
-      return id;
-    }
-  }  
+    return id;
+  } 
   
   bool epsEqual(double a, double b)
   {
@@ -406,7 +404,7 @@ namespace jsk_rviz_plugins
 
   void PictogramDisplay::processMessage(const jsk_rviz_plugins::Pictogram::ConstPtr& msg)
   {
-    boost::mutex::scoped_lock (mutex_);
+    boost::mutex::scoped_lock lock(mutex_);
 
     pictogram_->setEnable(isEnabled());
     if (!isEnabled()) {
@@ -437,7 +435,7 @@ namespace jsk_rviz_plugins
 
   void PictogramDisplay::update(float wall_dt, float ros_dt)
   {
-    boost::mutex::scoped_lock (mutex_);
+    boost::mutex::scoped_lock lock(mutex_);
     if (pictogram_) {
       pictogram_->update(wall_dt, ros_dt);
     }

--- a/jsk_rviz_plugins/src/segment_array_display.cpp
+++ b/jsk_rviz_plugins/src/segment_array_display.cpp
@@ -78,6 +78,7 @@ namespace jsk_rviz_plugins
     else if (coloring_method_ == "flat") {
       return color_;
     }
+    return QColor(255, 255, 255, 255);
   }
 
   void SegmentArrayDisplay::onInitialize()

--- a/jsk_rviz_plugins/src/view_controller/tablet_view_controller.cpp
+++ b/jsk_rviz_plugins/src/view_controller/tablet_view_controller.cpp
@@ -405,7 +405,7 @@ void TabletViewController::handleMouseEvent(ViewportMouseEvent& event)
   }
   if (event.type == QEvent::MouseButtonPress
       || event.type == QEvent::MouseButtonRelease
-      || dragging_ && event.type == QEvent::MouseMove) {
+      || (dragging_ && event.type == QEvent::MouseMove)) {
     publishMouseEvent(event);
   }
   float distance = distance_property_->getFloat();


### PR DESCRIPTION
I was seeing issues where after compiling the jsk_rviz_plugin source with Clang, the use of most any jsk plugin would cause the Ogre window for Rviz to freeze.  After fixing all the compiler warnings from Clang (lots of functions that end with no return value, and some locks without variable names -- things that aren't standard but g++ will "smooth over"), compiling jsk_rviz_plugins runs properly, whether compiled with g++ or with Clang.