### PR TITLE
[jsk_rviz_plugins] add warn for deprecated jsk_rviz_plugins/PoseArrayDisplay

### DIFF
--- a/jsk_rviz_plugins/src/pose_array_display.cpp
+++ b/jsk_rviz_plugins/src/pose_array_display.cpp
@@ -70,6 +70,7 @@ PoseArrayDisplay::~PoseArrayDisplay()
 
 void PoseArrayDisplay::onInitialize()
 {
+  ROS_WARN("jsk_rviz_plugins/PoseArrayDisplay is deprecated. Please use rviz default PoseArrayDisplay plugin instead.");
   MFDClass::onInitialize();
   manual_object_ = scene_manager_->createManualObject();
   manual_object_->setDynamic( true );
@@ -152,6 +153,7 @@ bool validateFloats( const geometry_msgs::PoseArray& msg )
 
 void PoseArrayDisplay::processMessage( const geometry_msgs::PoseArray::ConstPtr& msg )
 {
+  ROS_WARN_THROTTLE(1.0, "jsk_rviz_plugins/PoseArrayDisplay is deprecated. Please use rviz default PoseArrayDisplay plugin instead.");
   if( !validateFloats( *msg ))
   {
     setStatus( rviz::StatusProperty::Error, "Topic", "Message contained invalid floating point values (nans or infs)" );

--- a/jsk_rviz_plugins/src/pose_array_display.cpp
+++ b/jsk_rviz_plugins/src/pose_array_display.cpp
@@ -70,7 +70,9 @@ PoseArrayDisplay::~PoseArrayDisplay()
 
 void PoseArrayDisplay::onInitialize()
 {
+#if ROS_VERSION_MINIMUM(1,12,0)
   ROS_WARN("jsk_rviz_plugins/PoseArrayDisplay is deprecated. Please use rviz default PoseArrayDisplay plugin instead.");
+#endif
   MFDClass::onInitialize();
   manual_object_ = scene_manager_->createManualObject();
   manual_object_->setDynamic( true );
@@ -153,7 +155,9 @@ bool validateFloats( const geometry_msgs::PoseArray& msg )
 
 void PoseArrayDisplay::processMessage( const geometry_msgs::PoseArray::ConstPtr& msg )
 {
+#if ROS_VERSION_MINIMUM(1,12,0)
   ROS_WARN_THROTTLE(1.0, "jsk_rviz_plugins/PoseArrayDisplay is deprecated. Please use rviz default PoseArrayDisplay plugin instead.");
+#endif
   if( !validateFloats( *msg ))
   {
     setStatus( rviz::StatusProperty::Error, "Topic", "Message contained invalid floating point values (nans or infs)" );


### PR DESCRIPTION
fix #785 

warn that `jsk_rviz_plugins/PoseArrayDisplay` is deprecated when user uses it.
I update to show this warning on Kinetic and upper version.

cc. @pazeshun 
