### PR TITLE
[doc] Fix doc build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ script:
   - if [ "${CHECK_PYTHON3_COMPILE}" == "true" ]; then python3 -m compileall .; exit $?; fi
   - source .travis/travis.sh
   # test building sphinx documentation
-  - which virtualenv 2>/dev/null || pip install --user virtualenv
+  - which virtualenv 2>/dev/null || pip3 install --user virtualenv
   - (cd $TRAVIS_BUILD_DIR/doc && source setup.sh && make html)
 after_success:
   # trigger build of jsk-docs.readthedocs.org

--- a/doc/add_img_tables_to_index.py
+++ b/doc/add_img_tables_to_index.py
@@ -13,6 +13,7 @@ Usage::
 
 import hashlib
 import os
+import six
 import sys
 
 
@@ -33,7 +34,10 @@ def rst_image_table_data(url_prefix, img_files):
         if not any(map(os.path.exists, doc_candidates)):
             continue
         img_file = os.path.join(url_prefix, 'images', img_file)
-        label_name = hashlib.sha1(title).hexdigest()[:8]
+        if hasattr(title, 'encode'):
+            label_name = hashlib.sha1(title.encode('utf-8')).hexdigest()[:8]
+        else:
+            label_name = hashlib.sha1(title).hexdigest()[:8]
         labels.append('''\
 .. |{label}| image:: {img}
    :scale: 100%
@@ -47,7 +51,7 @@ def rst_image_table_data(url_prefix, img_files):
     # generate table
     table = []
     table.append('+------------+------------+------------+')
-    for i in xrange(0, len(blocks), N_COLUMN):
+    for i in six.moves.range(0, len(blocks), N_COLUMN):
         table.append('| ' + ' | '.join(blocks[i:i+N_COLUMN]) + ' |')
         table.append('+------------+------------+------------+')
     return '\n\n'.join(labels), '\n'.join(table)
@@ -82,4 +86,4 @@ def main(exclude_patterns):
 
 
 if __name__ == '__main__':
-    main()
+    main(['_build', 'venv'])

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -169,6 +169,8 @@ htmlhelp_basename = 'jsk_visualizationdoc'
 
 # -- Options for LaTeX output ---------------------------------------------
 
+latex_engine = 'platex'
+latex_use_xindy = False
 latex_elements = {
 # The paper size ('letterpaper' or 'a4paper').
 #'papersize': 'letterpaper',
@@ -178,7 +180,6 @@ latex_elements = {
 
     # Additional stuff for the LaTeX preamble.
     'preamble': "".join((
-        "\\usepackage[utf8]{inputenc}",
         # NO-BREAK SPACE
         '\DeclareUnicodeCharacter{00A0}{ }',
         # BOX DRAWINGS LIGHT VERTICAL AND RIGHT

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -10,6 +10,8 @@ from recommonmark.parser import CommonMarkParser
 
 
 extensions = [
+    'recommonmark',
+    'sphinx_markdown_tables',
     'sphinx.ext.mathjax',
 ]
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -195,7 +195,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  (master_doc, 'jsk_visualization.tex', u'jsk_visualization Documentation',
+  (master_doc, 'jsk_visualization.tex', u'jsk\_visualization Documentation',
    author, 'manual'),
 ]
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
 recommonmark==0.5.0
-Sphinx==1.8.4
+Sphinx==3.3.0
 sphinx-markdown-tables==0.0.9
 sphinx_rtd_theme==0.4.3

--- a/doc/setup.sh
+++ b/doc/setup.sh
@@ -4,6 +4,6 @@ type virtualenv &>/dev/null || {
   echo "Please install virtualenv" >&2
 }
 
-virtualenv venv
+virtualenv --python=python3 venv
 . venv/bin/activate
 pip install -r requirements.txt


### PR DESCRIPTION
- add escape in latex title
- support japanese for latex build in readthedoc
- fix add_img_tables_to_index.py for python3
- add missing extensions in conf.py

I tested with my readthedoc project.

