### PR TITLE
[jsk_rqt_plugins] add service_type and support Trigger for rqt service button

### DIFF
--- a/jsk_rqt_plugins/src/jsk_rqt_plugins/button_general.py
+++ b/jsk_rqt_plugins/src/jsk_rqt_plugins/button_general.py
@@ -220,7 +220,13 @@ class ServiceButtonGeneralWidget(QWidget):
     def buttonCallbackImpl(self, service_name, service_type=Empty):
         srv = rospy.ServiceProxy(service_name, service_type)
         try:
-            srv()
+            res = srv()
+            if hasattr(res, 'success'):
+                success = res.success
+                if not success:
+                    self.showError(
+                        "Succeeded to call {}, but service response is res.success=False"
+                        .format(service_name))
         except rospy.ServiceException as e:
             self.showError("Failed to call %s" % service_name)
 


### PR DESCRIPTION
add `service_type` in rqt_service_buttons and rqt_service_radio_buttons.
with this PR, we can use `std_srvs/Empty` and `std_srvs/Trigger`

```bash
- name: 'Trigger button'
  service: 'trigger'
  service_type: 'Trigger'
  column: 0
- name: 'Empty button'
  service: 'empty'
  service_type: 'Empty'
  column: 0
```