### PR TITLE
[jsk_rqt_plugins] Support SetBool for Service Buttons

### DIFF
--- a/jsk_rqt_plugins/resource/service_button_layout.yaml
+++ b/jsk_rqt_plugins/resource/service_button_layout.yaml
@@ -2,18 +2,24 @@
   service: 'dummy/buttonA'
   column: 0
   image: "package://jsk_rviz_plugins/icons/hand-grasp-pose.jpg"
+  service_type: 'SetBool'
 - name: 'Button B'
   service: 'dummy/buttonB'
   column: 0
+  service_type: 'SetBool'
 - name: 'Button C'
   service: 'dummy/buttonC'
   column: 0
+  service_type: 'SetBool'
+  default_value: true
 - name: 'Button D'
   service: 'dummy/buttonD'
   column: 1
+  service_type: 'Trigger'
 - name: 'Button E'
   service: 'dummy/buttonE'
   column: 1
+  service_type: 'Empty'
 - name: 'Button F'
   service: 'dummy/buttonF'
   column: 1

--- a/jsk_rqt_plugins/sample_scripts/sample_service_buttons.py
+++ b/jsk_rqt_plugins/sample_scripts/sample_service_buttons.py
@@ -4,18 +4,30 @@ import rospy
 
 from std_srvs.srv import Empty
 from std_srvs.srv import EmptyResponse
+from std_srvs.srv import SetBool
+from std_srvs.srv import SetBoolResponse
+from std_srvs.srv import Trigger
+from std_srvs.srv import TriggerResponse
 
 
 class SampleServiceButtons(object):
     def __init__(self):
         self.services = [
-            rospy.Service('dummy/buttonA', Empty, self._empty_cb),
-            rospy.Service('dummy/buttonB', Empty, self._empty_cb),
-            rospy.Service('dummy/buttonC', Empty, self._empty_cb),
-            rospy.Service('dummy/buttonD', Empty, self._empty_cb),
+            rospy.Service('dummy/buttonA', SetBool, self._set_bool_cb),
+            rospy.Service('dummy/buttonB', SetBool, self._set_bool_cb),
+            rospy.Service('dummy/buttonC', SetBool, self._set_bool_cb),
+            rospy.Service('dummy/buttonD', Trigger, self._trigger_cb),
             rospy.Service('dummy/buttonE', Empty, self._empty_cb),
             rospy.Service('dummy/buttonF', Empty, self._empty_cb),
         ]
+
+    def _set_bool_cb(self, req):
+        rospy.loginfo('SetBool service called: req.data={}'.format(req.data))
+        return SetBoolResponse(success=True)
+
+    def _trigger_cb(self, req):
+        rospy.loginfo('Trigger service called')
+        return TriggerResponse(success=True)
 
     def _empty_cb(self, req):
         rospy.loginfo('Empty service called')

--- a/jsk_rqt_plugins/src/jsk_rqt_plugins/button_general.py
+++ b/jsk_rqt_plugins/src/jsk_rqt_plugins/button_general.py
@@ -166,7 +166,7 @@ class ServiceButtonGeneralWidget(QWidget):
                     raise Exception("service field is missed in yaml")
                 if self.button_type == "push":
                     button = QToolButton()
-                else:  # self.button_type == "Radio":
+                else:  # self.button_type == "radio":
                     button = QRadioButton()
                 button.setSizePolicy(
                     QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred))


### PR DESCRIPTION
merge after #780 and #791 

Support `SetBool` service for `rqt_service_buttons`.

You can try with following command:

```bash
roslaunch jsk_rqt_plugins sample_service_buttons.launch
```

![rqt_service_buttons_set_bool](https://user-images.githubusercontent.com/9300063/99372643-cf084b00-2903-11eb-87bc-68d9a3d188c0.gif)