### PR TITLE
fix for using button_general.py without perspective file

### DIFF
--- a/jsk_rqt_plugins/sample/sample_service_buttons_wo_perspective.launch
+++ b/jsk_rqt_plugins/sample/sample_service_buttons_wo_perspective.launch
@@ -1,0 +1,8 @@
+<launch>
+  <node name="$(anon sample_buttons)"
+        pkg="jsk_rqt_plugins" type="rqt_service_buttons" output="screen" clear_params="true">
+    <param name="~layout_yaml_file" value="package://jsk_rqt_plugins/resource/service_button_layout.yaml" />
+  </node>
+  <node name="sample_service_buttons" pkg="jsk_rqt_plugins" type="sample_service_buttons.py"
+        output="screen"/>
+</launch>

--- a/jsk_rqt_plugins/src/jsk_rqt_plugins/button_general.py
+++ b/jsk_rqt_plugins/src/jsk_rqt_plugins/button_general.py
@@ -102,6 +102,10 @@ class ServiceButtonGeneralWidget(QWidget):
         self.button_type = button_type
         self._layout_param = None
         self._dialog = LineEditDialog()
+
+        if rospy.has_param("~layout_yaml_file"):
+            self.loadLayoutYaml(None)
+
         self.show()
 
     def showError(self, message):


### PR DESCRIPTION
For using rqt_service_buttons(button_general.py) without perspective file