### PR TITLE
Support single button setup in ServiceButtons plugin

### DIFF
--- a/jsk_rqt_plugins/src/jsk_rqt_plugins/button_general.py
+++ b/jsk_rqt_plugins/src/jsk_rqt_plugins/button_general.py
@@ -149,7 +149,10 @@ class ServiceButtonGeneralWidget(QWidget):
                     break
             # lookup column num
             column_indices = [d['column'] for d in yaml_data]
-            max_column_index = max(*column_indices)
+            if len(column_indices) > 1:
+                max_column_index = max(*column_indices)
+            else:
+                max_column_index = column_indices[0]
             if direction == 'vertical':
                 self.layout = QHBoxLayout()
                 self.layout_boxes = [QVBoxLayout()


### PR DESCRIPTION
* `*column_indices` expects to be an array of integers and the length
  should be equal or longer than 2.
* If column_indices is just an array of a single integer (length is
  1), do not apply sum with expanding a list argument.