### PR TITLE
#801 added a regex for "color: XXX;" pattern to have a properly colored shadow

### DIFF
--- a/jsk_rviz_plugins/src/overlay_text_display.cpp
+++ b/jsk_rviz_plugins/src/overlay_text_display.cpp
@@ -45,6 +45,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>
 #include <jsk_topic_tools/log_utils.h>
+#include <regex>
 
 namespace jsk_rviz_plugins
 {
@@ -267,9 +268,12 @@ namespace jsk_rviz_plugins
              % text_ % fg_color_.red() % fg_color_.green() % fg_color_.blue() %
              fg_color_.alpha()).str();
 
+        // find a remove "color: XXX;" regex match to generate a proper shadow 
+        std::regex color_tag_re("color:.+?;");
+        std::string formatted_text_ = std::regex_replace(text_, color_tag_re, "");
         std::string color_wrapped_shadow
           = (boost::format("<span style=\"color: rgba(%2%, %3%, %4%, %5%)\">%1%</span>")
-             % text_ % shadow_color.red() % shadow_color.green() % shadow_color.blue() % shadow_color.alpha()).str();
+             % formatted_text_ % shadow_color.red() % shadow_color.green() % shadow_color.blue() % shadow_color.alpha()).str();
 	
         QStaticText static_text(
           boost::algorithm::replace_all_copy(color_wrapped_text, "\n", "<br >").c_str());

--- a/jsk_rviz_plugins/src/overlay_text_display.cpp
+++ b/jsk_rviz_plugins/src/overlay_text_display.cpp
@@ -270,7 +270,8 @@ namespace jsk_rviz_plugins
 
         // find a remove "color: XXX;" regex match to generate a proper shadow 
         std::regex color_tag_re("color:.+?;");
-        std::string formatted_text_ = std::regex_replace(text_, color_tag_re, "");
+        std::string null_char("");
+        std::string formatted_text_ = std::regex_replace(text_, color_tag_re, null_char);
         std::string color_wrapped_shadow
           = (boost::format("<span style=\"color: rgba(%2%, %3%, %4%, %5%)\">%1%</span>")
              % formatted_text_ % shadow_color.red() % shadow_color.green() % shadow_color.blue() % shadow_color.alpha()).str();


### PR DESCRIPTION
Addresses https://github.com/jsk-ros-pkg/jsk_visualization/issues/801 
