### PR TITLE
Update URLs

### DIFF
--- a/jsk_rqt_plugins/package.xml
+++ b/jsk_rqt_plugins/package.xml
@@ -7,7 +7,7 @@
   <license>BSD</license>
   <url type="repository">http://github.com/jsk-ros-pkg/jsk_visualization</url>
   <url type="bugtracker">http://github.com/jsk-ros-pkg/jsk_visualization/issues</url>
-  <url type="website">http://jsk-docs.readthedocs.io/en/latest/jsk_visualization/doc/jsk_rqt_plugins</url>
+  <url type="website">https://jsk-visualization.readthedocs.io/en/latest/jsk_rqt_plugins/index.html</url>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/jsk_rviz_plugins/package.xml
+++ b/jsk_rviz_plugins/package.xml
@@ -11,7 +11,7 @@
   <author email="ueda@jsk.t.u-tokyo.ac.jp">Ryohei Ueda</author>
   <url type="repository">http://github.com/jsk-ros-pkg/jsk_visualization</url>
   <url type="bugtracker">http://github.com/jsk-ros-pkg/jsk_visualization/issues</url>
-  <url type="website">http://jsk-docs.readthedocs.io/en/latest/jsk_visualization/doc/jsk_rviz_plugins</url>
+  <url type="website">https://jsk-visualization.readthedocs.io/en/latest/jsk_rviz_plugins/index.html</url>
 
   <buildtool_depend>catkin</buildtool_depend>
 


### PR DESCRIPTION
Updating the URLs of the jsk_rviz_plugins and jsk_rqt_plugins so the generated README points to working links (closes https://github.com/jsk-ros-pkg/jsk_visualization/issues/805 ).