### PR TITLE
Remove has_key for python3 compatibility

### DIFF
--- a/jsk_interactive_markers/jsk_interactive_marker/scripts/transformable_markers_client.py
+++ b/jsk_interactive_markers/jsk_interactive_marker/scripts/transformable_markers_client.py
@@ -36,7 +36,7 @@ class TransformableMarkersClient(object):
             rospy.logfatal("config_file '{}' does not exist"
                            .format(self.config_file))
             sys.exit(1)
-        self.config = yaml.load(open(self.config_file))
+        self.config = yaml.safe_load(open(self.config_file))
 
         self.req_marker = rospy.ServiceProxy(
             osp.join(self.server, 'request_marker_operate'),

--- a/jsk_rqt_plugins/package.xml
+++ b/jsk_rqt_plugins/package.xml
@@ -30,8 +30,7 @@
   <exec_depend>image_view2</exec_depend>
   <exec_depend version_gte="4.3.0" >jsk_gui_msgs</exec_depend>
   <exec_depend>cv_bridge</exec_depend>
-  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-urlgrabber</exec_depend>
-  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-urlgrabber</exec_depend>
+  <exec_depend>python-urlgrabber</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-sklearn</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-sklearn</exec_depend>
   <exec_depend>message_runtime</exec_depend>

--- a/jsk_rqt_plugins/src/jsk_rqt_plugins/button_general.py
+++ b/jsk_rqt_plugins/src/jsk_rqt_plugins/button_general.py
@@ -140,7 +140,7 @@ class ServiceButtonGeneralWidget(QWidget):
             # lookup colum direction
             direction = 'vertical'
             for d in yaml_data:
-                if d.has_key('direction'):
+                if 'direction' in d:
                     if d['direction'] == 'horizontal':
                         direction = 'horizontal'
                     else: # d['direction'] == 'vertical':
@@ -165,10 +165,10 @@ class ServiceButtonGeneralWidget(QWidget):
                                   for i in range(max_column_index + 1)]
             for button_data in yaml_data:
                 # check if all the field is available
-                if not button_data.has_key("name"):
+                if "name" not in button_data:
                     self.showError("name field is missed in yaml")
                     raise Exception("name field is missed in yaml")
-                if not button_data.has_key("service"):
+                if "service" not in button_data:
                     self.showError("service field is missed in yaml")
                     raise Exception("service field is missed in yaml")
                 if self.button_type == "push":
@@ -177,22 +177,22 @@ class ServiceButtonGeneralWidget(QWidget):
                     button = QRadioButton()
                 button.setSizePolicy(
                     QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred))
-                if button_data.has_key("image"):
+                if "image" in button_data:
                     image_file = get_filename(
                         button_data["image"])[len("file://"):]
                     if os.path.exists(image_file):
                         icon = QtGui.QIcon(image_file)
                         button.setIcon(icon)
-                        if button_data.has_key("image_size"):
+                        if "image_size" in button_data:
                             button.setIconSize(QSize(
                                 button_data["image_size"][0],
                                 button_data["image_size"][1]))
                         else:
                             button.setIconSize(QSize(100, 100))
-                if button_data.has_key("name"):
+                if "name" in button_data:
                     name = button_data['name']
                     button.setText(name)
-                if button_data.has_key('service_type'):
+                if 'service_type' in button_data:
                     if button_data['service_type'] == 'Trigger':
                         service_type = Trigger
                     elif button_data['service_type'] == 'Empty':

--- a/jsk_rqt_plugins/src/jsk_rqt_plugins/button_general.py
+++ b/jsk_rqt_plugins/src/jsk_rqt_plugins/button_general.py
@@ -136,7 +136,7 @@ class ServiceButtonGeneralWidget(QWidget):
         """
         self.buttons = []
         with open(yaml_file) as f:
-            yaml_data = yaml.load(f)
+            yaml_data = yaml.safe_load(f)
             # lookup colum direction
             direction = 'vertical'
             for d in yaml_data:

--- a/jsk_rviz_plugins/scripts/motor_states_temperature_decomposer.py
+++ b/jsk_rviz_plugins/scripts/motor_states_temperature_decomposer.py
@@ -24,9 +24,9 @@ def allocatePublishers(num):
 def allocateEffortPublishers(names):
     global g_effort_publishers
     for name in names:
-        if not g_effort_publishers.has_key(name):
+        if name not in g_effort_publishers:
             g_effort_publishers[name] = rospy.Publisher('effort_%s' % (name), Float32, queue_size=1)
-        
+
 def motorStatesCallback(msg):
     global g_publishers, g_text_publisher
     #values = msg.position


### PR DESCRIPTION
This PR replaces the deprecated `has_key` function using the `in` keyword. `has_key` was deprectaed in python 3.x, so the current code fails when executed with a python3 interpreter.
Also changes `pyyaml` `load` to `safe_load` as it is a much safer option (this also gets rid of the warning in python3).
This fix should work on both python2 and 3.

After this PR, I was able to run `button_general` in python3.