### PR TITLE
[jsk_rviz_plugins] resolve circular dependency in jsk_rviz_plugins/package.xml

### DIFF
--- a/jsk_rviz_plugins/package.xml
+++ b/jsk_rviz_plugins/package.xml
@@ -65,8 +65,8 @@
   <test_depend>python-gdown-pip</test_depend> <!-- install_sample_data requries gdown -->
   <test_depend>openni2_launch</test_depend> <!-- normal.test, face_detector.test requires openni2_launch -->
   <test_depend>image_transport</test_depend> <!-- normal.test, face_detector.test requires image_transport -->
-  <test_depend>jsk_pcl_ros_utils</test_depend> <!-- normal.test requires jsk_pcl/NormalConcatenater -->
-  <test_depend>jsk_pcl_ros</test_depend> <!-- normal.test requires jsk_pcl/NormalConcatenater (for kinetic) -->
+  <!--test_depend>jsk_pcl_ros_utils</test_depend--> <!-- normal.test requires jsk_pcl/NormalConcatenater -->
+  <!-- test_depend>jsk_pcl_ros</test_depend--> <!-- normal.test requires jsk_pcl/NormalConcatenater (for kinetic) -->
   <test_depend>face_detector</test_depend> <!-- face_detector.test requires face_detector -->
 
   <export>


### PR DESCRIPTION
resolve circular dependency in jsk_rviz_plugins

```
$ catkin_topological_order
The workspace contains packages with a circular dependency: jsk_interactive_marker, jsk_pcl_ros, jsk_rviz_plugins

$ catkin build
[build] Error: The workspace packages have a circular dependency, and cannot be built. Please run `catkin list --deps` to determine the problematic package(s).
```