### PR TITLE
Change pie chart color at your custom threshold

### DIFF
--- a/doc/jsk_rviz_plugins/plugins/pie_chart.md
+++ b/doc/jsk_rviz_plugins/plugins/pie_chart.md
@@ -5,7 +5,79 @@ Plot a pie chart of `std_msgs/Float32` on rviz as HUD overlay.
 
 To change caption text, please [rename plugin display name](http://docs.ros.org/jade/api/rviz/html/user_guide/#naming-displays) on rviz Displays tab
 
+## Properties
+* `Topic`
+
+  `std_msgs::Float32` topic to subscribe to
+* `size`
+
+  Size of the plotter window
+* `left`
+
+  Left of the plotter window
+* `top`
+
+  Top of the plotter window
+* `foreground color`
+  
+  Color to draw line
+* `foreground alpha`
+  
+  Alpha belnding value for foreground
+* `foreground alpha2`
+
+  Alpha belnding value for foreground for indicator
+* `background color`
+
+  Background color
+* `background alpha`
+
+  Alpha belnding value for background
+* `text size`
+
+  Text size
+* `show caption`
+
+  Show caption
+* `max value`
+
+  Max value of pie chart
+* `min value`
+
+  Min value of pie chart
+* `auto color change`
+
+  Change the color automatically
+* `max color`
+ 
+  Max color of pie chart 
+  
+  Only used if auto color change is set to True
+* `med color`
+
+  Med color of pie chart
+  
+  Only used if auto color change is set to True
+* `max color change threshold`
+
+  Change the max color at this threshold
+  
+  Only used if auto color change is set to True
+* `med color change threshold`
+
+  Change the med color at this threshold
+  
+  Only used if auto color change is set to True
+* `clockwise rotate direction`
+
+  Change the rotate direction
+
+
 ## Sample
 ```
 roslaunch jsk_rviz_plugins overlay_sample.launch
+```
+  or
+```
+roslaunch jsk_rviz_plugins piechart_sample.launch
 ```

--- a/jsk_rviz_plugins/src/pie_chart_display.cpp
+++ b/jsk_rviz_plugins/src/pie_chart_display.cpp
@@ -111,6 +111,22 @@ namespace jsk_rviz_plugins
                                 "only used if auto color change is set to True.",
                                 this, SLOT(updateMaxColor()));
 
+    med_color_property_
+      = new rviz::ColorProperty("med color",
+                                QColor(255, 0, 0),
+                                "only used if auto color change is set to True.",
+                                this, SLOT(updateMedColor()));
+
+    max_color_threshold_property_
+      = new rviz::FloatProperty("max color change threthold", 0,
+                                  "change the max color at threshold",
+                                  this, SLOT(updateMaxColorThreshold()));
+   
+    med_color_threshold_property_
+      = new rviz::FloatProperty("med color change threthold", 0,
+                                  "change the med color at threshold ",
+                                  this, SLOT(updateMedColorThreshold()));
+    
     clockwise_rotate_property_
       = new rviz::BoolProperty("clockwise rotate direction",
                                false,
@@ -134,6 +150,8 @@ namespace jsk_rviz_plugins
     delete size_property_;
     delete min_value_property_;
     delete max_value_property_;
+    delete max_color_property_;
+    delete med_color_property_;
     delete text_size_property_;
     delete show_caption_property_;
   }
@@ -159,6 +177,9 @@ namespace jsk_rviz_plugins
     updateShowCaption();
     updateAutoColorChange();
     updateMaxColor();
+    updateMedColor();
+    updateMaxColorThreshold();
+    updateMedColorThreshold();
     updateClockwiseRotate();
     overlay_->updateTextureSize(texture_size_, texture_size_ + caption_offset_);
     overlay_->hide();
@@ -205,6 +226,20 @@ namespace jsk_rviz_plugins
                           + fg_color_.green());
         fg_color.setBlue((max_color_.blue() - fg_color_.blue()) * r2
                          + fg_color_.blue());
+      }
+      if (max_color_threshold_ != 0) {
+        if (r > max_color_threshold_) {
+        fg_color.setRed(max_color_.red());
+        fg_color.setGreen(max_color_.green());
+        fg_color.setBlue(max_color_.blue());
+        }
+      }
+      if (med_color_threshold_ != 0) {
+        if (max_color_threshold_ > r and r > med_color_threshold_ ) {
+        fg_color.setRed(med_color_.red());
+        fg_color.setGreen(med_color_.green());
+        fg_color.setBlue(med_color_.blue());
+        }
       }
     }
 
@@ -403,9 +438,15 @@ namespace jsk_rviz_plugins
     auto_color_change_ = auto_color_change_property_->getBool();
     if (auto_color_change_) {
       max_color_property_->show();
+      med_color_property_->show();
+      max_color_threshold_property_->show();
+      med_color_threshold_property_->show();
     }
     else {
       max_color_property_->hide();
+      med_color_property_->hide();
+      max_color_threshold_property_->hide();
+      med_color_threshold_property_->hide();
     }
     update_required_ = true;
 
@@ -416,6 +457,25 @@ namespace jsk_rviz_plugins
     max_color_ = max_color_property_->getColor();
     update_required_ = true;
 
+  }
+
+  void PieChartDisplay::updateMedColor()
+  {
+    med_color_ = med_color_property_->getColor();
+    update_required_ = true;
+
+  }
+
+  void PieChartDisplay::updateMaxColorThreshold()
+  {
+    max_color_threshold_ = max_color_threshold_property_->getFloat();
+    update_required_ = true;
+  }
+
+  void PieChartDisplay::updateMedColorThreshold()
+  {
+    med_color_threshold_ = med_color_threshold_property_->getFloat();
+    update_required_ = true;
   }
 
   void PieChartDisplay::updateClockwiseRotate()

--- a/jsk_rviz_plugins/src/pie_chart_display.h
+++ b/jsk_rviz_plugins/src/pie_chart_display.h
@@ -92,6 +92,9 @@ namespace jsk_rviz_plugins
     rviz::BoolProperty* show_caption_property_;
     rviz::BoolProperty* auto_color_change_property_;
     rviz::ColorProperty* max_color_property_;
+    rviz::ColorProperty* med_color_property_;
+    rviz::FloatProperty* max_color_threshold_property_;
+    rviz::FloatProperty* med_color_threshold_property_;
     rviz::BoolProperty* clockwise_rotate_property_;
 
     ros::Subscriber sub_;
@@ -101,6 +104,7 @@ namespace jsk_rviz_plugins
     QColor fg_color_;
     QColor bg_color_;
     QColor max_color_;
+    QColor med_color_;
     int text_size_;
     bool show_caption_;
     bool auto_color_change_;
@@ -110,6 +114,8 @@ namespace jsk_rviz_plugins
     double bg_alpha_;
     double max_value_;
     double min_value_;
+    double max_color_threshold_;
+    double med_color_threshold_;
     float data_;
     bool update_required_;
     bool first_time_;
@@ -134,6 +140,9 @@ namespace jsk_rviz_plugins
     void updateShowCaption();
     void updateAutoColorChange();
     void updateMaxColor();
+    void updateMedColor();
+    void updateMaxColorThreshold();
+    void updateMedColorThreshold();
     void updateClockwiseRotate();
 
   private:


### PR DESCRIPTION
[Pie chart] 
You can set the max color and med color at your custom max and med color threshold after enabling `auto color change`.

e.x. 
1. `roslaunch jsk_rviz_plugins piechart_sample.launch`
2. Enable `auto color change` on rviz
3. Set max color (med color)
4. Set max threshold (med threshold)

https://user-images.githubusercontent.com/42209144/143372588-07feb002-7d5d-4d41-a48e-bef074767c5e.mp4

