### PR TITLE
[jsk_rviz_plugins] Fixed Camera Info visualization

### DIFF
--- a/jsk_rviz_plugins/src/camera_info_display.cpp
+++ b/jsk_rviz_plugins/src/camera_info_display.cpp
@@ -415,6 +415,13 @@ namespace jsk_rviz_plugins
     try
     {
       cv_ptr = cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::RGB8);
+      if (cv_ptr->image.cols != camera_info_->width
+          || cv_ptr->image.rows != camera_info_->height) {
+        ROS_ERROR("Invalid image size (w, h) = (%d, %d), expected (w, h) = (%d, %d)",
+                  cv_ptr->image.cols, cv_ptr->image.rows,
+                  camera_info_->width, camera_info_->height);
+        return;
+      }
       cv::Rect roi(camera_info_->roi.x_offset, camera_info_->roi.y_offset,
                    camera_info_->roi.width ? camera_info_->roi.width : camera_info_->width,
                    camera_info_->roi.height ? camera_info_->roi.height : camera_info_->height);

--- a/jsk_rviz_plugins/src/camera_info_display.cpp
+++ b/jsk_rviz_plugins/src/camera_info_display.cpp
@@ -429,7 +429,7 @@ namespace jsk_rviz_plugins
         cv::cvtColor(im, im, cv::COLOR_BGR2RGB);
       } else if (msg->encoding == enc::RGBA8 || msg->encoding == enc::RGBA16) {
         cv::cvtColor(im, im, cv::COLOR_RGBA2RGB);
-      } else if (msg->encoding == enc::BGR8 || msg->encoding == enc::BGR16) {
+      } else if (msg->encoding == enc::RGB8 || msg->encoding == enc::RGB16) {
         // nothing
       } else if (msg->encoding == enc::MONO8) {
         cv::cvtColor(im, im, cv::COLOR_GRAY2RGB);

--- a/jsk_rviz_plugins/src/camera_info_display.cpp
+++ b/jsk_rviz_plugins/src/camera_info_display.cpp
@@ -423,15 +423,29 @@ namespace jsk_rviz_plugins
     {
       cv_ptr = cv_bridge::toCvShare(msg);
       cv::Mat im = cv_ptr->image.clone();
-      if (msg->encoding == enc::BGRA8 || msg->encoding == enc::BGRA16) {
+      if (msg->encoding == enc::BGRA8) {
         cv::cvtColor(im, im, cv::COLOR_BGRA2RGB);
-      } else if (msg->encoding == enc::BGR8 || msg->encoding == enc::BGR16) {
+      } else if (msg->encoding == enc::BGRA16) {
+        im.convertTo(im, CV_8U, 1 / 256.0);
+        cv::cvtColor(im, im, cv::COLOR_BGRA2RGB);
+      } else if (msg->encoding == enc::BGR8) {
         cv::cvtColor(im, im, cv::COLOR_BGR2RGB);
-      } else if (msg->encoding == enc::RGBA8 || msg->encoding == enc::RGBA16) {
+      } else if (msg->encoding == enc::BGR16) {
+        im.convertTo(im, CV_8U, 1 / 256.0);
+        cv::cvtColor(im, im, cv::COLOR_BGR2RGB);
+      } else if (msg->encoding == enc::RGBA8) {
         cv::cvtColor(im, im, cv::COLOR_RGBA2RGB);
-      } else if (msg->encoding == enc::RGB8 || msg->encoding == enc::RGB16) {
+      } else if (msg->encoding == enc::RGBA16) {
+        im.convertTo(im, CV_8U, 1 / 256.0);
+        cv::cvtColor(im, im, cv::COLOR_RGBA2RGB);
+      } else if (msg->encoding == enc::RGB8) {
         // nothing
+      } else if (msg->encoding == enc::RGB16) {
+        im.convertTo(im, CV_8U, 1 / 256.0);
       } else if (msg->encoding == enc::MONO8) {
+        cv::cvtColor(im, im, cv::COLOR_GRAY2RGB);
+      } else if (msg->encoding == enc::MONO16) {
+        im.convertTo(im, CV_8U, 1 / 256.0);
         cv::cvtColor(im, im, cv::COLOR_GRAY2RGB);
       } else {
         ROS_ERROR("[CameraInfoDisplay] Not supported image encodings %s.", msg->encoding.c_str());


### PR DESCRIPTION
# What is this?

`CameraInfo` plugin in `jsk_rviz_plugins` is not visualizing camera info correctly when roi and binning are set.
Following video shows the result of decimated `CameraInfo` in https://github.com/jsk-ros-pkg/jsk_recognition/pull/2713 
Command is `roslaunch jsk_perception sample_robot_to_mask_image.launch gui:=true decimate:=true`

https://user-images.githubusercontent.com/4690682/179243344-3da8f2fd-9757-47d9-8572-e65c5020ae0a.mp4

This PR properly visualizes `CameraInfo` as shown in the following video by properly calculating roi and binning.

https://user-images.githubusercontent.com/4690682/179243701-a8f4ccac-04d7-4ee3-8467-4ef90082010b.mp4


