### PR TITLE
Fixed linear gague display

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -58,7 +58,7 @@ jobs:
           fi
 
       - name: Chcekout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.0.2
 
       - name: Cache Download Data
         uses: actions/cache@v3

--- a/jsk_rviz_plugins/src/linear_gauge_display.cpp
+++ b/jsk_rviz_plugins/src/linear_gauge_display.cpp
@@ -243,12 +243,12 @@ namespace jsk_rviz_plugins
     //draw gauge
     if(vertical_gauge_)
     {
-        double normalised_value = std::min(std::max((double)data_, 0.0), max_value_)*(h-2*height_padding_)/max_value_;
+        double normalised_value = std::min(std::max((double)data_ - min_value_, 0.0), max_value_ - min_value_)*(h-2*height_padding_)/(max_value_-min_value_);
         painter.fillRect(width_padding_, h-normalised_value-height_padding_, w-2*width_padding_, normalised_value, fg_color);
     }
     else
     {   
-        double normalised_value = std::min(std::max((double)data_, 0.0), max_value_)*(w-2*width_padding_)/max_value_;
+        double normalised_value = std::min(std::max((double)data_ - min_value_, 0.0), max_value_ - min_value_)*(w-2*width_padding_)/(max_value_-min_value_);
         painter.fillRect(width_padding_, height_padding_, normalised_value, h-(2*height_padding_), fg_color);
     }
   


### PR DESCRIPTION
If the minimum of the linear gauge is not zero, it incorrectly displays the "progress". This PR fixes it.

Previously non-working config:

Min value 24, max value 25, current value 24.5.

Previous normalized_value would be `min(max(24.5,0), 25) * width / 25 = min(24.5, 25) * width / 25 = 24.5 * width / 25 = almost 100% width`, while it should be 50%.

New normalized value is `min(max(24.5-24, 0), 25 - 24) * width / (25-24) = min(0.5, 1) * width / 1 = 50% width`.