### PR TITLE
Fix simultaneous display of OverlayCamera and OverlayImage

### DIFF
--- a/jsk_rviz_plugins/src/overlay_camera_display.cpp
+++ b/jsk_rviz_plugins/src/overlay_camera_display.cpp
@@ -398,7 +398,7 @@ void OverlayCameraDisplay::update( float wall_dt, float ros_dt )
   if (!overlay_) {
     static int count = 0;
     rviz::UniformStringStream ss;
-    ss << "OverlayImageDisplayObject" << count++;
+    ss << "OverlayCameraImageDisplayObject" << count++;
     overlay_.reset(new OverlayObject(ss.str()));
     overlay_->show();
   }


### PR DESCRIPTION
Without this change, adding both OverlayCamera and OverlayImage to one rviz window crashes with:

```
[ WARN] [1669695420.835465329, 1666865132.227821766] [ros.rviz]: OGRE EXCEPTION(4:ItemIdentityException): Overlay with name 'OverlayImageDisplayObject0' already exists! in OverlayManager::create at /build/ogre-1.9-CZD0Iy/ogre-1.9-1.9.0+dfsg1/Components/Overlay/src/OgreOverlayManager.cpp (line 109)
terminate called after throwing an instance of 'Ogre::ItemIdentityException'
  what():  OGRE EXCEPTION(4:ItemIdentityException): Overlay with name 'OverlayImageDisplayObject0' already exists! in OverlayManager::create at /build/ogre-1.9-CZD0Iy/ogre-1.9-1.9.0+dfsg1/Components/Overlay/src/OgreOverlayManager.cpp (line 109)
```

I'm not really sure whether it is correct that I made this string different from the similar one used in the OverlayCamera (`OverlayCameraDisplayObject`). If these two should be the same, I can update the PR.