### PR TITLE
add test to check 'genpy.message.SerializationError: field width must be an integer type'

### DIFF
--- a/jsk_rviz_plugins/cfg/OverlayTextInterface.cfg
+++ b/jsk_rviz_plugins/cfg/OverlayTextInterface.cfg
@@ -8,10 +8,10 @@ from dynamic_reconfigure.parameter_generator_catkin import *;
 from math import pi
 
 gen = ParameterGenerator ()
-gen.add("width", double_t, 0, "", 1200, -1, 2024)
-gen.add("height", double_t, 0, "", 800, -1, 2024)
-gen.add("top", double_t, 0, "", 10, 0, 2024)
-gen.add("left", double_t, 0, "", 10, 0, 2024)
+gen.add("width", int_t, 0, "", 1200, -1, 2024)
+gen.add("height", int_t, 0, "", 800, -1, 2024)
+gen.add("top", int_t, 0, "", 10, 0, 2024)
+gen.add("left", int_t, 0, "", 10, 0, 2024)
 
 gen.add("text_size", double_t, 0, "", 12, 1, 32)
 

--- a/jsk_rviz_plugins/package.xml
+++ b/jsk_rviz_plugins/package.xml
@@ -62,6 +62,7 @@
   <test_depend>joint_state_publisher</test_depend> <!-- link_marker_publisher_sample.launch, contact_state_marker_sample.launch requires joint_state_publisher -->
   <test_depend>robot_state_publisher</test_depend> <!-- link_marker_publisher_sample.launch, contact_state_marker_sample.launch requires robot_state_publisher -->
   <test_depend>jsk_data</test_depend> <!-- install_sample_data requries jsk_data -->
+  <test_depend>jsk_tools</test_depend> <!-- test_overlay_text_interface.test requries jsk_tools -->
   <test_depend>python-gdown-pip</test_depend> <!-- install_sample_data requries gdown -->
   <test_depend>openni2_launch</test_depend> <!-- normal.test, face_detector.test requires openni2_launch -->
   <test_depend>image_transport</test_depend> <!-- normal.test, face_detector.test requires image_transport -->

--- a/jsk_rviz_plugins/test/test_overlay_text_interface.py
+++ b/jsk_rviz_plugins/test/test_overlay_text_interface.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+###############################################################################
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2021, Kei Okada
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+
+from __future__ import print_function
+
+import sys
+import traceback
+import rospy
+
+from jsk_rviz_plugins.msg import OverlayText
+from jsk_rviz_plugins.overlay_text_interface import OverlayTextInterface
+
+rospy.init_node('publish_overlay_text_interface')
+text_interface = OverlayTextInterface("~text")
+rospy.loginfo("publish text_interface")
+rate = rospy.Rate(1)
+
+try:
+    while not rospy.is_shutdown():
+        rospy.loginfo("publish text_interface")
+        text_interface.publish("test")
+        rate.sleep()
+except rospy.ROSException as e:
+    print(traceback.format_exc(), file=sys.stderr)
+    sys.exit(1)

--- a/jsk_rviz_plugins/test/test_overlay_text_interface.test
+++ b/jsk_rviz_plugins/test/test_overlay_text_interface.test
@@ -1,0 +1,13 @@
+<launch>
+  <node name="publish_overlay_text_interface"
+        pkg="jsk_rviz_plugins" type="test_overlay_text_interface.py"
+        required="true" />
+  <test test-name="test_overlay_text_interface"
+        pkg="jsk_tools" type="test_topic_published.py"
+        time-limit="15" retry="2">
+    <rosparam>
+      topic_0: /publish_overlay_text_interface/text
+      timeout_0: 15
+    </rosparam>
+  </test>
+</launch>


### PR DESCRIPTION
this only happens in noetic, to fix this we need to fix `OverlayTextInterface.cfg` compatible with `OverText.msg`

```
  File "/home/k-okada/catkin_ws/jsk_recognition_ws/devel/lib/python3/dist-packages/jsk_rviz_plugins/msg/_OverlayText.py", line 127, in serialize
    except struct.error as se: self._check_types(struct.error("%s: '%s' when writing '%s'" % (type(se), str(se), str(locals().get('_x', self)))))
  File "/opt/ros/noetic/lib/python3/dist-packages/genpy/message.py", line 393, in _check_types
    check_type(n, t, getattr(self, n))
  File "/opt/ros/noetic/lib/python3/dist-packages/genpy/message.py", line 261, in check_type
    raise SerializationError('field %s must be an integer type' % field_name)
genpy.message.SerializationError: field width must be an integer type
```