### PR TITLE
Fix QPainterPath path has incomplete type and cannot be defined

### DIFF
--- a/jsk_rviz_plugins/src/overlay_diagnostic_display.h
+++ b/jsk_rviz_plugins/src/overlay_diagnostic_display.h
@@ -42,6 +42,7 @@
 #include <OGRE/OgreMaterial.h>
 
 #include <QPainter>
+#include <QPainterPath>
 
 #include <rviz/properties/ros_topic_property.h>
 #include <rviz/properties/editable_enum_property.h>


### PR DESCRIPTION
While building the jsk_rviz_plugins from source on a ubuntu 22.04 system in a catkin workspace, had the following error message. And to fix it, included the _QPainterPath_ header.

> jsk_visualization/jsk_rviz_plugins/src/overlay_diagnostic_display.cpp:388:18: error: aggregate ‘QPainterPath path’ has incomplete type and cannot be defined
>   388 |     QPainterPath path;