### PR TITLE
use qt key namespace

### DIFF
--- a/jsk_rviz_plugins/src/overlay_picker_tool.cpp
+++ b/jsk_rviz_plugins/src/overlay_picker_tool.cpp
@@ -61,10 +61,10 @@ namespace jsk_rviz_plugins
 
   int OverlayPickerTool::processKeyEvent(QKeyEvent* event, rviz::RenderPanel* panel)
   {
-    if (event->type() == QEvent::KeyPress && event->key() == 16777248) { // sift
+    if (event->type() == QEvent::KeyPress && event->key() == Qt::Key_Shift) { // shift
       shift_pressing_ = true;
     }
-    else if (event->type() == QEvent::KeyRelease && event->key() == 16777248) {
+    else if (event->type() == QEvent::KeyRelease && event->key() == Qt::Key_Shift) {
       shift_pressing_ = false;
     }
     return 0;


### PR DESCRIPTION
this is refactored version of #855 

the magic number `16777248` comes from `QT::Key_Shift`.
```
In [1]: 0x01000020
Out[1]: 16777248
```

https://doc.qt.io/qt-5/qt.html

```
Qt::Key_Shift | 0x01000020
```