### PR TITLE
[jsk_rviz_plugins][Plotter2D] add option to control text size in plot

### DIFF
--- a/jsk_rviz_plugins/src/plotter_2d_display.cpp
+++ b/jsk_rviz_plugins/src/plotter_2d_display.cpp
@@ -119,6 +119,12 @@ namespace jsk_rviz_plugins
     text_size_property_ = new rviz::IntProperty("text size", 12,
                                                 "text size of the caption",
                                                 this, SLOT(updateTextSize()));
+    auto_text_size_in_plot_property_ = new rviz::BoolProperty("auto text size in plot", true,
+                                                              "automatiacally adjust text size of the value in plot",
+                                                              this, SLOT(updateAutoTextSizeInPlot()));
+    text_size_in_plot_property_ = new rviz::IntProperty("text size in plot", 12,
+                                                        "text size of the value in plot",
+                                                        this, SLOT(updateTextSizeInPlot()));
     text_size_property_->setMin(1);
     text_size_property_->setMax(1000);
     show_caption_property_ = new rviz::BoolProperty(
@@ -208,6 +214,8 @@ namespace jsk_rviz_plugins
     updateAutoScale();
     updateMinValue();
     updateMaxValue();
+    updateTextSizeInPlot();
+    updateAutoTextSizeInPlot();
     overlay_->updateTextureSize(width_property_->getInt(),
                                 height_property_->getInt() + caption_offset_);
   }
@@ -293,7 +301,11 @@ namespace jsk_rviz_plugins
       }
       if (show_value_) {
         QFont font = painter.font();
-        font.setPointSize(w / 4);
+        if (auto_text_size_in_plot_) {
+          font.setPointSize(w / 4);
+        } else {
+          font.setPointSize(text_size_in_plot_);
+        }
         font.setBold(true);
         painter.setFont(font);
         std::ostringstream ss;
@@ -532,6 +544,21 @@ namespace jsk_rviz_plugins
     }
     updateMinValue();
     updateMaxValue();
+  }
+
+  void Plotter2DDisplay::updateAutoTextSizeInPlot(){
+    auto_text_size_in_plot_ = auto_text_size_in_plot_property_->getBool();
+    if (auto_text_size_in_plot_) {
+      text_size_in_plot_property_->hide();
+    }
+    else {
+      text_size_in_plot_property_->show();
+    }
+    updateTextSizeInPlot();
+  }
+
+  void Plotter2DDisplay::updateTextSizeInPlot(){
+    text_size_in_plot_ = text_size_in_plot_property_->getInt();
   }
 
   bool Plotter2DDisplay::isInRegion(int x, int y)

--- a/jsk_rviz_plugins/src/plotter_2d_display.h
+++ b/jsk_rviz_plugins/src/plotter_2d_display.h
@@ -102,7 +102,9 @@ namespace jsk_rviz_plugins
     rviz::BoolProperty* auto_scale_property_;
     rviz::FloatProperty* max_value_property_;
     rviz::FloatProperty* min_value_property_;
-    
+    rviz::BoolProperty* auto_text_size_in_plot_property_;
+    rviz::IntProperty* text_size_in_plot_property_;
+
     OverlayObject::Ptr overlay_;
     QColor fg_color_;
     QColor max_color_;
@@ -118,6 +120,8 @@ namespace jsk_rviz_plugins
     bool draw_required_;
     float last_time_;
     float update_interval_;
+    bool auto_text_size_in_plot_;
+    int text_size_in_plot_;
     
     int buffer_length_;
     std::vector<double> buffer_;
@@ -159,6 +163,9 @@ namespace jsk_rviz_plugins
     void updateAutoScale();
     void updateMinValue();
     void updateMaxValue();
+    void updateTextSizeInPlot();
+    void updateAutoTextSizeInPlot();
+
   private:
   };
 }


### PR DESCRIPTION
One solution to solve https://github.com/jsk-ros-pkg/jsk_visualization/issues/862 .

Adding `auto_text_size_in_plot` property and if it is enabled, the rviz automatically adjust text size in Plotter2D.
<img width="553" alt="image" src="https://user-images.githubusercontent.com/27789460/236651596-21fe90cd-ec3d-4604-9887-499b56c7d69e.png">

When `auto_text_size_in_plot` is disabled, you can control text size in Plotter2D by editing `text_size_in_plot` manually.
<img width="518" alt="image" src="https://user-images.githubusercontent.com/27789460/236651628-cca7ae72-b7d2-4eeb-b39c-fb2b4514080a.png">


