### PR TITLE
[jsk_rqt_plugins] Fix super function argument in tabbed_button_general

### DIFF
--- a/jsk_rqt_plugins/src/jsk_rqt_plugins/tabbed_button_general.py
+++ b/jsk_rqt_plugins/src/jsk_rqt_plugins/tabbed_button_general.py
@@ -140,7 +140,7 @@ class ServiceButtonGeneralWidget_in_tab(ServiceButtonGeneralWidget):
     Qt widget to visualize multiple buttons
     """
     def __init__(self, settings):
-        super(ServiceButtonGeneralWidget, self).__init__()
+        super(ServiceButtonGeneralWidget_in_tab, self).__init__()
         yaml_file = settings['yaml_file']
         namespace = None
         if 'type' in settings:


### PR DESCRIPTION
The argument of the super function in `tabbed_button_general.py` has been modified so that it does not cause errors.  

```bash
roslaunch jsk_rqt_plugins sample_tabbed_buttons.launch 
```
Before the modification, the following error occurred when executing the above sample, but after the modification, the inheritance of member variables required by https://github.com/jsk-ros-pkg/jsk_visualization/commit/4961b6987d3adda8eaf644c5e111cf9d225f7044 is successfully performed and the error does not occur.  
```bash
  File "/home/kanazawa/vive_ws/src/jsk-ros-pkg/jsk_visualization/jsk_rqt_plugins/src/jsk_rqt_plugins/tabbed_button_general.py", line 158, in __init__
    self._translator.tr("YAML files (*.yaml *.yml)"))
AttributeError: 'ServiceButtonGeneralWidget_in_tab' object has no attribute '_translator'
```
cc. @ojh6404 