### PR TITLE
[jsk_rqt_plugins] Fix yaml load in tabbed_button_general.py

### DIFF
--- a/jsk_rqt_plugins/src/jsk_rqt_plugins/tabbed_button_general.py
+++ b/jsk_rqt_plugins/src/jsk_rqt_plugins/tabbed_button_general.py
@@ -162,7 +162,7 @@ class ServiceButtonGeneralWidget_in_tab(ServiceButtonGeneralWidget):
             resolved_yaml = resolved_yaml[len("file://"):]
 
         with open(resolved_yaml) as f:
-            yaml_data = yaml.load(f)
+            yaml_data = yaml.safe_load(f)
             self.setupButtons_with_yaml_data(yaml_data=yaml_data, namespace=namespace)
 
         self.show()


### PR DESCRIPTION
The https://github.com/jsk-ros-pkg/jsk_visualization/pull/811 (https://github.com/jsk-ros-pkg/jsk_visualization/pull/818) change was not applied to tabbed_button_general.py, so I added it.

When using PyYAML version 6.0 or later, the old way of writing `yaml.load()` causes an error. https://github.com/yaml/pyyaml/issues/576