### PR TITLE
[ROS-O] patches

### DIFF
--- a/jsk_interactive_markers/jsk_interactive_marker/CMakeLists.txt
+++ b/jsk_interactive_markers/jsk_interactive_marker/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(jsk_interactive_marker)
 
-if("$ENV{ROS_DISTRO}" STREQUAL "kinetic")
+if(("$ENV{ROS_DISTRO}" STREQUAL "kinetic") OR ("$ENV{ROS_DISTRO}" STREQUAL "indigo"))
   # catch special case ROS kinetic where c++11 is not the default yet
   add_compile_options(-std=c++11)
 endif()

--- a/jsk_interactive_markers/jsk_interactive_marker/CMakeLists.txt
+++ b/jsk_interactive_markers/jsk_interactive_marker/CMakeLists.txt
@@ -1,9 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(jsk_interactive_marker)
 
-if("$ENV{ROS_DISTRO}" STRGREATER "melodic")
-  add_compile_options(-std=c++14)
-else()
+if("$ENV{ROS_DISTRO}" STREQUAL "kinetic")
+  # catch special case ROS kinetic where c++11 is not the default yet
   add_compile_options(-std=c++11)
 endif()
 

--- a/jsk_rqt_plugins/CMakeLists.txt
+++ b/jsk_rqt_plugins/CMakeLists.txt
@@ -32,7 +32,7 @@ install(DIRECTORY launch resource sample sample_scripts test
 
 if (CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
-  if("$ENV{ROS_DISTRO}" STRGREATER "indigo")
+  if(NOT "$ENV{ROS_DISTRO}" STREQUAL "indigo")
     catkin_add_nosetests(test)
     add_rostest(test/test_rqt_plugins.test)
   endif()

--- a/jsk_rviz_plugins/CMakeLists.txt
+++ b/jsk_rviz_plugins/CMakeLists.txt
@@ -4,9 +4,8 @@
 # http://ros.org/doc/groovy/api/catkin/html/user_guide/supposed.html
 cmake_minimum_required(VERSION 2.8.3)
 project(jsk_rviz_plugins)
-if("$ENV{ROS_DISTRO}" STRGREATER "melodic")
-  add_compile_options(-std=c++14)
-else()
+if("$ENV{ROS_DISTRO}" STREQUAL "kinetic")
+  # catch special case ROS kinetic where c++11 is not the default yet
   add_compile_options(-std=c++11)
 endif()
 # Load catkin and all dependencies required for this package

--- a/jsk_rviz_plugins/CMakeLists.txt
+++ b/jsk_rviz_plugins/CMakeLists.txt
@@ -4,7 +4,7 @@
 # http://ros.org/doc/groovy/api/catkin/html/user_guide/supposed.html
 cmake_minimum_required(VERSION 2.8.3)
 project(jsk_rviz_plugins)
-if("$ENV{ROS_DISTRO}" STREQUAL "kinetic")
+if(("$ENV{ROS_DISTRO}" STREQUAL "kinetic") OR ("$ENV{ROS_DISTRO}" STREQUAL "indigo"))
   # catch special case ROS kinetic where c++11 is not the default yet
   add_compile_options(-std=c++11)
 endif()

--- a/jsk_rviz_plugins/src/camera_info_display.h
+++ b/jsk_rviz_plugins/src/camera_info_display.h
@@ -53,6 +53,7 @@
 #include <OGRE/OgreSceneManager.h>
 #include <OGRE/OgreTextureManager.h>
 #include <OGRE/OgreTexture.h>
+#include <OGRE/OgreTechnique.h>
 #include <cv_bridge/cv_bridge.h>
 #include <sensor_msgs/image_encodings.h>
 #include <image_transport/subscriber.h>

--- a/jsk_rviz_plugins/src/overlay_camera_display.cpp
+++ b/jsk_rviz_plugins/src/overlay_camera_display.cpp
@@ -206,7 +206,11 @@ void OverlayCameraDisplay::onInitialize()
 
     bg_screen_rect_->setRenderQueueGroup(Ogre::RENDER_QUEUE_BACKGROUND);
     bg_screen_rect_->setBoundingBox(aabInf);
+#if ((OGRE_VERSION_MAJOR << 16) | (OGRE_VERSION_MINOR << 8) | OGRE_VERSION_PATCH) < ((1 << 16) | (10 << 8) | 0)
     bg_screen_rect_->setMaterial(bg_material_->getName());
+#else
+    bg_screen_rect_->setMaterial(bg_material_);
+#endif
 
     bg_scene_node_->attachObject(bg_screen_rect_);
     bg_scene_node_->setVisible(false);
@@ -217,7 +221,11 @@ void OverlayCameraDisplay::onInitialize()
 
     fg_material_ = bg_material_->clone( ss.str()+"fg" );
     fg_screen_rect_->setBoundingBox(aabInf);
+#if ((OGRE_VERSION_MAJOR << 16) | (OGRE_VERSION_MINOR << 8) | OGRE_VERSION_PATCH) < ((1 << 16) | (10 << 8) | 0)
     fg_screen_rect_->setMaterial(fg_material_->getName());
+#else
+    fg_screen_rect_->setMaterial(fg_material_);
+#endif
 
     fg_material_->setSceneBlending( Ogre::SBT_TRANSPARENT_ALPHA );
     fg_screen_rect_->setRenderQueueGroup(Ogre::RENDER_QUEUE_OVERLAY - 1);

--- a/jsk_rviz_plugins/src/overlay_utils.h
+++ b/jsk_rviz_plugins/src/overlay_utils.h
@@ -50,6 +50,7 @@
   #include <OGRE/OgreOverlayContainer.h>
   #include <OGRE/OgreOverlayManager.h>
 #else
+  #include <OGRE/Overlay/OgreOverlay.h>
   #include <OGRE/Overlay/OgrePanelOverlayElement.h>
   #include <OGRE/Overlay/OgreOverlayElement.h>
   #include <OGRE/Overlay/OgreOverlayContainer.h>

--- a/jsk_rviz_plugins/src/polygon_array_display.h
+++ b/jsk_rviz_plugins/src/polygon_array_display.h
@@ -47,6 +47,7 @@
 #include <OGRE/OgreSceneNode.h>
 #include <OGRE/OgreManualObject.h>
 #include <OGRE/OgreMaterialManager.h>
+#include <OGRE/OgreTechnique.h>
 #include <rviz/properties/color_property.h>
 #include <rviz/properties/bool_property.h>
 #include <rviz/properties/enum_property.h>


### PR DESCRIPTION
The first commit supports ROS_DISTRO values out of alphabetic order (also discussed [here](https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/509#issuecomment-2483167494)).

The second is required for OGRE 1.12 (partly Ubuntu noble, definitely Debian bookworm, and newer).

@mqcmd196 