### PR TITLE
fix CI, override node20 directory.

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -30,7 +30,11 @@ jobs:
             CONTAINER: ubuntu:20.04
             BEFORE_SCRIPT: "pip3 install -U --user pyyaml"
 
-    container: ${{ matrix.CONTAINER }}
+    container:
+      image: ${{ matrix.CONTAINER }}
+      volumes:
+        - /tmp/node20:/__e/node20
+
     steps:
       - name: Install latest git ( use sudo for ros-ubuntu )
         run: |
@@ -60,6 +64,21 @@ jobs:
           else
              git config --global --add safe.directory $GITHUB_WORKSPACE
           fi
+
+      - name: Try to replace `node` with an glibc 2.17
+        shell: bash
+        run: |
+          if [ "${{ matrix.CONTAINER }}" = "jskrobotics/ros-ubuntu:14.04" ]; then
+             export USER=$(whoami)
+             sudo chmod 777 -R /__e/node20
+             sudo chown -R $USER /__e/node20
+          fi
+          ls -lar /__e/node20 &&
+          sudo apt-get install -y curl &&
+          curl -Lo /tmp/node.tar.gz https://unofficial-builds.nodejs.org/download/release/v20.17.0/node-v20.17.0-linux-x64-glibc-217.tar.gz &&
+          cd /__e/node20 &&
+          tar -x --strip-components=1 -f /tmp/node.tar.gz &&
+          ls -lar /__e/node20/bin/
 
       - name: Chcekout
         uses: actions/checkout@v3.0.2


### PR DESCRIPTION
fix CI, override node20. See https://github.com/actions/upload-artifact/issues/616#issuecomment-2350667347
c.f. https://github.com/jsk-ros-pkg/jsk_control/pull/790

```
Post job cleanup.
/usr/bin/docker exec  a73c1686824111e1103ab64b9f540a586c9548c53a8213840c21206b2f17403a sh -c "cat /etc/*release | grep ^ID"
OCI runtime exec failed: exec failed: unable to start container process: exec: "/__e/node20/bin/node": stat /__e/node20/bin/node: no such file or directory: unknown
```