### PR TITLE
Remove gdown key

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -34,6 +34,7 @@ jobs:
       image: ${{ matrix.CONTAINER }}
       volumes:
         - /tmp/node20:/__e/node20
+      options: --user root
 
     steps:
       - name: Install latest git ( use sudo for ros-ubuntu )

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -86,7 +86,7 @@ jobs:
           submodules: true
 
       - name: Cache Download Data
-        uses: actions/cache@v3.0.4
+        uses: actions/cache@v4
         with:
           path: /github/home/.ros/data/jsk_rviz_plugins
           key: jsk_rviz_plugins

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -167,7 +167,7 @@ jobs:
           set -x
           # setup catkin tools
           apt install -qq -y python3-pip
-          pip3 install catkin-tools
+          pip3 install catkin-tools==0.9.4
           # setup build tools
           apt install -qq -y cmake build-essential catkin ros-one-rosbash
 

--- a/jsk_rviz_plugins/package.xml
+++ b/jsk_rviz_plugins/package.xml
@@ -63,7 +63,6 @@
   <test_depend>robot_state_publisher</test_depend> <!-- link_marker_publisher_sample.launch, contact_state_marker_sample.launch requires robot_state_publisher -->
   <test_depend>jsk_data</test_depend> <!-- install_sample_data requries jsk_data -->
   <test_depend>jsk_tools</test_depend> <!-- test_overlay_text_interface.test requries jsk_tools -->
-  <test_depend>python-gdown-pip</test_depend> <!-- install_sample_data requries gdown -->
   <test_depend>openni2_launch</test_depend> <!-- normal.test, face_detector.test requires openni2_launch -->
   <test_depend>image_transport</test_depend> <!-- normal.test, face_detector.test requires image_transport -->
   <!--test_depend>jsk_pcl_ros_utils</test_depend--> <!-- normal.test requires jsk_pcl/NormalConcatenater -->


### PR DESCRIPTION
`gdown` is not used now.

```shell
❯ git grep gdown
jsk_rviz_plugins/CHANGELOG.rst:  * install gdown / jsk_pcl_ros_utils for install_sample_data
jsk_rviz_plugins/package.xml:  <test_depend>python-gdown-pip</test_depend> <!-- install_sample_data requries gdown -->
```
